### PR TITLE
Improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 # saleor-platform
 All Saleor services started from a single repository
 
-*Keep in mind this repository is for local development only and is not meant to be deployed on any production environment! If you're not a developer and just want to try out Saleor you can check our [live demo](https://demo.saleor.io/).*
+*Keep in mind this repository is for local development only and is not meant to be deployed in any production environment! If you're not a developer and just want to try out Saleor you can check our [live demo](https://demo.saleor.io/).*
 
 ## Requirements
 1. [Docker](https://docs.docker.com/install/)
 2. [Docker Compose](https://docs.docker.com/compose/install/)
 
+## How to clone the repository?
+
+To clone the repository, run the following command
+
+```
+git clone https://github.com/saleor/saleor-platform.git --recursive --jobs 3
+```
 
 ## How to run it?
 
 ### With Makefile
-You can run few make commands
+We prepared a few `make` commands for you
 
 #### Bootstrap app
 ```shell
@@ -32,48 +39,42 @@ See [Makefile](Makefile) for all commands
 
 ### With Docker steps
 
-1. Clone the repository:
-
-```
-git clone https://github.com/saleor/saleor-platform.git --recursive --jobs 3
-```
-
-2. We are using shared folders to enable live code reloading. Without this, Docker Compose will not start:
+1. We are using shared folders to enable live code reloading. Without this, Docker Compose will not start:
     - Windows/MacOS: Add the cloned `saleor-platform` directory to Docker shared directories (Preferences -> Resources -> File sharing).
     - Windows/MacOS: Make sure that in Docker preferences you have dedicated at least 5 GB of memory (Preferences -> Resources -> Advanced).
-    - Linux: No action required, sharing already enabled and memory for Docker engine is not limited.
+    - Linux: No action is required, sharing is already enabled and memory for the Docker engine is not limited.
 
-3. Go to the cloned directory:
+2. Go to the cloned directory:
 ```shell
 cd saleor-platform
 ```
 
-4. Build the application:
+3. Build the application:
 ```shell
 docker-compose build
 ```
 
-5. Apply Django migrations:
+4. Apply Django migrations:
 ```shell
 docker-compose run --rm api python3 manage.py migrate
 ```
 
-6. Collect static files:
+5. Collect static files:
 ```shell
 docker-compose run --rm api python3 manage.py collectstatic --noinput
 ```
 
-7. Populate the database with example data and create the admin user:
+6. Populate the database with example data and create the admin user:
 ```shell
 docker-compose run --rm api python3 manage.py populatedb --createsuperuser
 ```
 *Note that `--createsuperuser` argument creates an admin account for `admin@example.com` with the password set to `admin`.*
 
-8. Run the application:
+7. Run the application:
 ```shell
 docker-compose up
 ```
-*Both storefront and dashboard are quite big frontend projects and it might take up to few minutes for them to compile depending on your CPU. If nothing shows up on port 3001 or 9000 wait until `Compiled successfully` shows in the console output.*
+*Both Storefront and Dashboard are quite big frontend projects and it might take up to a few minutes for them to compile depending on your CPU. If nothing shows up on port 3001 or 9000, please wait until `Compiled successfully` shows in the console output.*
 
 ## Where is the application running?
 - Saleor Core (API) - http://localhost:8000
@@ -83,20 +84,20 @@ docker-compose up
 - Mailhog (Test email interface) - http://localhost:8025 
 
 ## How to update the subprojects to the newest versions?
-This repository contains newest stable versions.
-When new release appear, pull new version of this repository.
-In order to update all of them to their newest versions, run:
+This repository contains the newest stable versions.
+When a new release is published, pull a new version of this repository.
+In order to update all of the subprojects to their newest versions, run:
 ```shell
 git submodule update --remote
 ```
 
-You can find the latest version of Saleor, storefront and dashboard in their individual repositories:
+You can find the latest version of Saleor, Storefront and Dashboard in their individual repositories:
 
 - https://github.com/saleor/saleor
 - https://github.com/saleor/saleor-dashboard
 - https://github.com/saleor/react-storefront
 
-## How to solve issues with lack of available space or build errors after update
+## How to solve issues with lack of available space or build errors after an update
 
 Most of the time both issues can be solved by cleaning up space taken by old containers. After that, we build again whole platform. 
 
@@ -108,7 +109,7 @@ docker-compose stop
 
 2. Remove existing volumes
 
-**Warning!** Proceeding will remove also your database container! If you need existing data, please remove only services which cause problems! https://docs.docker.com/compose/reference/rm/
+**Warning!** Proceeding will remove also your database container! If you need existing data, please remove only services that cause problems! https://docs.docker.com/compose/reference/rm/
 ```shell
 docker-compose rm
 ```
@@ -118,11 +119,11 @@ docker-compose rm
 docker-compose build
 ```
 
-4. Now you can run fresh environment using commands from `How to run it?` section. Done!
+4. Now you can run a fresh environment using commands from `How to run it?` section. Done!
 
 ### Still no available space
 
-If you are getting issues with lack of available space, consider prunning your docker cache:
+If you are getting issues with lack of available space, consider pruning your docker cache:
 
 **Warning!** This will remove:
   - all stopped containers


### PR DESCRIPTION
**The why:**
I wanted to try out the new `make` commands, and I noticed that the "how to run" section of the documentation consists of two paths: "With Makefile" and "With Docker steps".

However, only of those paths ("With Docker steps") includes the command to clone the repository which is quite important, as the command is a bit unusual.

**The what:**
I decided to move the "how to clone the repository" command before we present the ways you can run `saleor-platform`.

While I was doing that, I (and Grammarly) also fixed some grammar errors.