### PR TITLE
Add note about saleor-app-checkout, fix ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,5 @@ run-backend:
 	docker-compose up api worker
 upgrade:
 	git submodule update --remote
+tunnel:
+	cd ./react-storefront/apps/saleor-app-checkout && npx saleor app tunnel 3001

--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,5 @@ run-backend:
 	docker-compose up api worker
 upgrade:
 	git submodule update --remote
-tunnel:
+tunnel-checkout:
 	cd ./react-storefront/apps/saleor-app-checkout && npx saleor app tunnel 3001

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ make run
 make run-backend 
 ```
 
+### Expose saleor-app-checkout
+```shell
+make tunnel
+```
+
+> Note
+> `saleor-app-checkout` needs to be installed manually in Saleor Dashboard
+
 See [Makefile](Makefile) for all commands 
 
 ### With Docker steps
@@ -85,7 +93,8 @@ docker-compose up
 
 ## Where is the application running?
 - Saleor Core (API) - http://localhost:8000
-- Saleor React Storefront - http://localhost:3001
+- Saleor React Storefront - http://localhost:3000
+- Saleor App Checkout - http://localhost:3001
 - Saleor Dashboard - http://localhost:9000
 - Jaeger UI (APM) - http://localhost:16686
 - Mailhog (Test email interface) - http://localhost:8025 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make run-backend
 
 ### Expose saleor-app-checkout
 ```shell
-make tunnel
+make tunnel-checkout
 ```
 
 > Note


### PR DESCRIPTION
This PR adds information about installing Saleor App Checkout (tunnel) and fixes wrong ports used in README
