### PR TITLE
Use uvicorn as the ASGI server instead of old WSGI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./saleor/tests/:/app/tests
       # shared volume between worker and api for media
       - saleor-media:/app/media
-    command: python manage.py runserver 0.0.0.0:8000
+    command: uvicorn --host 0.0.0.0 --port 8000 --reload saleor.asgi:application
     env_file:
       - common.env
       - backend.env


### PR DESCRIPTION
Saleor is an ASGI app, and we use ASGI in production so running it locally should result in the same behavior.