### PR TITLE
Bump saleor core to 3.12.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   api:
-    image: ghcr.io/saleor/saleor:3.12.5
+    image: ghcr.io/saleor/saleor:3.12.7
     ports:
       - 8000:8000
     restart: unless-stopped


### PR DESCRIPTION
Notes:
- https://github.com/saleor/saleor/releases/tag/3.12.7
- https://github.com/saleor/saleor/releases/tag/3.12.6