### PR TITLE
Update Celery workers to use Saleor 3.12.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - saleor-redis:/data
 
   worker:
-    image: ghcr.io/saleor/saleor:3.12.5
+    image: ghcr.io/saleor/saleor:3.12.7
     command: celery -A saleor --app=saleor.celeryconf:app worker --loglevel=info -B
     restart: unless-stopped
     networks:


### PR DESCRIPTION
Follow-up of https://github.com/saleor/saleor-platform/commit/7bb2ae7befdcd19b89ede6524e99c277a4003065, Celery worker container wasn't upgraded.