### PR TITLE
Bump Saleor Core to v3.12.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   api:
-    image: ghcr.io/saleor/saleor:3.12.7
+    image: ghcr.io/saleor/saleor:3.12.8
     ports:
       - 8000:8000
     restart: unless-stopped
@@ -56,7 +56,7 @@ services:
       - saleor-redis:/data
 
   worker:
-    image: ghcr.io/saleor/saleor:3.12.7
+    image: ghcr.io/saleor/saleor:3.12.8
     command: celery -A saleor --app=saleor.celeryconf:app worker --loglevel=info -B
     restart: unless-stopped
     networks:


### PR DESCRIPTION
Upgrade Saleor Core to v3.12.8.
Release notes: https://github.com/saleor/saleor/releases/tag/3.12.8