### PR TITLE
Upgrade Redis to latest minor version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - POSTGRES_PASSWORD=saleor
 
   redis:
-    image: library/redis:5.0-alpine
+    image: library/redis:7.0-alpine
     ports:
       - 6379:6379
     restart: unless-stopped


### PR DESCRIPTION
Redis 5.0 reached EOL during 2022, 7.0 is the latest supported minor version.