### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @saleor/sre


### PR DESCRIPTION
Now that this repository only consists of Docker Compose config, there is no machinery that needs SRE approval.