### PR TITLE
Expose env variable in env file HTTP_IP_FILTER_ENABLED

### DIFF
--- a/common.env
+++ b/common.env
@@ -2,3 +2,7 @@ DEFAULT_CHANNEL_SLUG=default-channel
 # Note: recommended value is False for production usage,
 # refer to documentation for more details.
 HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS=True
+# https://docs.saleor.io/docs/3.x/setup/configuration#http_ip_filter_enabled
+# Set to false to enable local apps development using docker host
+# Read more: https://docs.saleor.io/docs/3.x/developer/extending/apps/local-app-development
+HTTP_IP_FILTER_ENABLED=True

--- a/common.env
+++ b/common.env
@@ -3,6 +3,7 @@ DEFAULT_CHANNEL_SLUG=default-channel
 # refer to documentation for more details.
 HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS=True
 # https://docs.saleor.io/docs/3.x/setup/configuration#http_ip_filter_enabled
-# Set to false to enable local apps development using docker host
+# Set to False to enable local apps development using docker host
 # Read more: https://docs.saleor.io/docs/3.x/developer/extending/apps/local-app-development
+# Note: recommended value for production is True
 HTTP_IP_FILTER_ENABLED=True


### PR DESCRIPTION
I exposed env variable with it's default value (True), so I can document it with a comment. App developers can now quickly change its value to enable app development environment