### PR TITLE
Update API and worker images tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   api:
-    image: ghcr.io/saleor/saleor:latest
+    image: ghcr.io/saleor/saleor:3.17
     ports:
       - 8000:8000
     restart: unless-stopped
@@ -56,7 +56,7 @@ services:
       - saleor-redis:/data
 
   worker:
-    image: ghcr.io/saleor/saleor:latest
+    image: ghcr.io/saleor/saleor:3.17
     command: celery -A saleor --app=saleor.celeryconf:app worker --loglevel=info -B
     restart: unless-stopped
     networks:


### PR DESCRIPTION
Update API and worker images tags to `3.17` as `latest` is not working as expected yet.