### PR TITLE
fix jaeger from creating unnamed volume for /tmp

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,9 @@ services:
     restart: unless-stopped
     networks:
       - saleor-backend-tier
+    volumes:
+      - type: tmpfs
+        target: /tmp
 
   mailpit:
     image: axllent/mailpit


### PR DESCRIPTION
The _jaegertracing/all-in-one_ image has a /tmp volume specified in it. Since no volume are mounted in the docker-compose.yaml for jaeger, new unnamed volumes are created on the host each time the container start.

Ref: [https://github.com/jaegertracing/jaeger/pull/1571/files](https://github.com/jaegertracing/jaeger/pull/1571/files)