### PR TITLE
chore: remove 'version' from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   api:
     image: ghcr.io/saleor/saleor:3.19


### PR DESCRIPTION
'version' is obsolete 

https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element-obsolete

Related Open [Issue](https://github.com/saleor/saleor-platform/issues/306)