### PR TITLE
Add script to prepare platform setup to run automation tests.

### DIFF
--- a/run-automation.sh
+++ b/run-automation.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 SNAPSHOT=$DIR"/update-automation-snapshot.sql"
-perl -pi -e 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHOT
+# perl -pi -e 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHOT
+sed -i '' 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHOT
+sed -i '' 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHOT
 # please note that you should not use this password on production services
 DB_URL="postgresql://saleor:saleor@localhost:5432/"
 FULL_DB_URL=$DB_URL"e2e"

--- a/run-automation.sh
+++ b/run-automation.sh
@@ -5,7 +5,7 @@ perl -pi -e 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHO
 # please note that you should not use this password on production services
 DB_URL="postgresql://saleor:saleor@localhost:5432/"
 FULL_DB_URL=$DB_URL"e2e"
-psql $DB_URL -c 'DROP DATABASE IF EXISTS e2e;'
+psql $DB_URL -c 'DROP DATABASE IF EXISTS e2e WITH(FORCE);'
 psql $DB_URL -c 'CREATE DATABASE e2e;' 
 psql $FULL_DB_URL -c 'CREATE EXTENSION IF NOT EXISTS btree_gin; CREATE EXTENSION IF NOT EXISTS pg_trgm;'
 psql $FULL_DB_URL -f $SNAPSHOT

--- a/run-automation.sh
+++ b/run-automation.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+SNAPSHOT=$DIR"/update-automation-snapshot.sql"
+perl -pi -e 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHOT
+# please note that you should not use this password on production services
+DB_URL="postgresql://saleor:saleor@localhost:5432/"
+FULL_DB_URL=$DB_URL"e2e"
+psql $DB_URL -c 'DROP DATABASE IF EXISTS e2e;'
+psql $DB_URL -c 'CREATE DATABASE e2e;' 
+psql $FULL_DB_URL -c 'CREATE EXTENSION IF NOT EXISTS btree_gin; CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+psql $FULL_DB_URL -f $SNAPSHOT

--- a/run-automation.sh
+++ b/run-automation.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 SNAPSHOT=$DIR"/update-automation-snapshot.sql"
-# perl -pi -e 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHOT
 sed -i '' 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHOT
 sed -i '' 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHOT
 # please note that you should not use this password on production services
@@ -11,3 +10,4 @@ psql $DB_URL -c 'DROP DATABASE IF EXISTS e2e WITH(FORCE);'
 psql $DB_URL -c 'CREATE DATABASE e2e;' 
 psql $FULL_DB_URL -c 'CREATE EXTENSION IF NOT EXISTS btree_gin; CREATE EXTENSION IF NOT EXISTS pg_trgm;'
 psql $FULL_DB_URL -f $SNAPSHOT
+docker compose exec api python manage.py migrate

--- a/setup-e2e-db.sh
+++ b/setup-e2e-db.sh
@@ -1,13 +1,28 @@
 #!/bin/bash
+# Script to load update-automation-snapshot into our database (to public schema)
+# It needs the docker compose from saleor platform repository: https://github.com/saleor/saleor-platform
+# Tested only on MacOs
+
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 SNAPSHOT=$DIR"/update-automation-snapshot.sql"
+# make sure to use `public` schema
 sed -i '' 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHOT
 sed -i '' 's/update_automation_snapshot_staging_saleor_cloud/public/' $SNAPSHOT
+
 # please note that you should not use this password on production services
 DB_URL="postgresql://saleor:saleor@localhost:5432/"
+# use different database for testing purpose
 FULL_DB_URL=$DB_URL"e2e"
+
+# drop previous database
 psql $DB_URL -c 'DROP DATABASE IF EXISTS e2e WITH(FORCE);'
+
+# create new database and make sure to install needed extensions
 psql $DB_URL -c 'CREATE DATABASE e2e;' 
 psql $FULL_DB_URL -c 'CREATE EXTENSION IF NOT EXISTS btree_gin; CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+
+# load the snapshot
 psql $FULL_DB_URL -f $SNAPSHOT
+
+# make sure to run migrations in case snapshot is not up to date with `core` migrations
 docker compose exec api python manage.py migrate


### PR DESCRIPTION
The script takes the snapshot named: `update-automation-snapshot.sql`
and makes sure that it is running on `public` schema instead of defined one in the script.

Next it makes sure to correctly import the snapshot and fill missing migrations if new ones appeared after snapshot was taken.