### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   api:
     image: ghcr.io/saleor/saleor:3.20


### PR DESCRIPTION
When launching any `docker compose` command, there was a warning:

WARN[0000] docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 

This PR proposes to remove the version in docker-compose.yml to avoid this warning