### PR TITLE
fix: permission denied when starting PostgreSQL in Fedora

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - saleor-backend-tier
     volumes:
       - saleor-db:/var/lib/postgresql/data
-      - ./replica_user.sql:/docker-entrypoint-initdb.d/replica_user.sql
+      - ./replica_user.sql:/docker-entrypoint-initdb.d/replica_user.sql:ro,z
     environment:
       - POSTGRES_USER=saleor
       - POSTGRES_PASSWORD=saleor


### PR DESCRIPTION
This fixes the following crash in fedora:

```
$ podman-compose up db
[db]        | ls: /docker-entrypoint-initdb.d/replica_user.sql: Permission denied
```

This is likely caused by the podman file mapping behaving differently in Fedora (for example, it was working on Ubuntu 24.04 but not Fedora 41)

----

This should resolve https://github.com/saleor/saleor-platform/issues/325