### PR TITLE
fix: allow HTTP access via 127.0.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - backend.env
     environment:
       - DASHBOARD_URL=http://localhost:9000/
-      - ALLOWED_HOSTS=localhost,api
+      - ALLOWED_HOSTS=localhost,127.0.0.1,api
 
   dashboard:
     image: ghcr.io/saleor/saleor-dashboard:latest


### PR DESCRIPTION
When accessing the API via 127.0.0.1, it was raising `django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: '127.0.0.1:8000'. You may need to add '127.0.0.1' to ALLOWED_HOSTS.`