### PR TITLE
fix: use all 4 vCPUs in pytest CI/CD

### DIFF
--- a/.github/workflows/test-platform.yml
+++ b/.github/workflows/test-platform.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Build
         run: docker compose build
       - name: Run backend tests
-        run: docker compose run api pytest --allow-hosts cache
+        run: docker compose run api pytest -n logical --allow-hosts cache


### PR DESCRIPTION
`pytest` CI/CD was using only 2 vCPUs out of 4, thus was slower than it could be.

Saves ~5 minutes