### PR TITLE
feat: RoverChat Bytes top-up products (#61)

### DIFF
--- a/.agents/skills/supabase-postgres-best-practices/CHANGELOG.md
+++ b/.agents/skills/supabase-postgres-best-practices/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## [1.3.0](https://github.com/supabase/agent-skills/compare/v1.2.0...v1.3.0) (2026-06-05)
+
+
+### Features
+
+* add schema-constraints reference for safe migration patterns ([#30](https://github.com/supabase/agent-skills/issues/30)) ([9b236f3](https://github.com/supabase/agent-skills/commit/9b236f3ebd65d76a2c570f19931353da9c858d5a))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* correct broken reference link in postgres best practices skill ([#58](https://github.com/supabase/agent-skills/issues/58)) ([f4e2277](https://github.com/supabase/agent-skills/commit/f4e22777fd8573537297b568c16e5a45a25927da))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))
+
+## [1.2.0](https://github.com/supabase/agent-skills/compare/v1.1.1...v1.2.0) (2026-06-02)
+
+
+### Features
+
+* add schema-constraints reference for safe migration patterns ([#30](https://github.com/supabase/agent-skills/issues/30)) ([9b236f3](https://github.com/supabase/agent-skills/commit/9b236f3ebd65d76a2c570f19931353da9c858d5a))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* correct broken reference link in postgres best practices skill ([#58](https://github.com/supabase/agent-skills/issues/58)) ([f4e2277](https://github.com/supabase/agent-skills/commit/f4e22777fd8573537297b568c16e5a45a25927da))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))

--- a/.agents/skills/supabase-postgres-best-practices/SKILL.md
+++ b/.agents/skills/supabase-postgres-best-practices/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: supabase-postgres-best-practices
+description: Postgres performance optimization and best practices from Supabase. Use this skill when writing, reviewing, or optimizing Postgres queries, schema designs, or database configurations.
+license: MIT
+metadata:
+  author: supabase
+  version: "1.1.1"
+  organization: Supabase
+  date: January 2026
+  abstract: Comprehensive Postgres performance optimization guide for developers using Supabase and Postgres. Contains performance rules across 8 categories, prioritized by impact from critical (query performance, connection management) to incremental (advanced features). Each rule includes detailed explanations, incorrect vs. correct SQL examples, query plan analysis, and specific performance metrics to guide automated optimization and code generation.
+---
+
+# Supabase Postgres Best Practices
+
+Comprehensive performance optimization guide for Postgres, maintained by Supabase. Contains rules across 8 categories, prioritized by impact to guide automated query optimization and schema design.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing SQL queries or designing schemas
+- Implementing indexes or query optimization
+- Reviewing database performance issues
+- Configuring connection pooling or scaling
+- Optimizing for Postgres-specific features
+- Working with Row-Level Security (RLS)
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Query Performance | CRITICAL | `query-` |
+| 2 | Connection Management | CRITICAL | `conn-` |
+| 3 | Security & RLS | CRITICAL | `security-` |
+| 4 | Schema Design | HIGH | `schema-` |
+| 5 | Concurrency & Locking | MEDIUM-HIGH | `lock-` |
+| 6 | Data Access Patterns | MEDIUM | `data-` |
+| 7 | Monitoring & Diagnostics | LOW-MEDIUM | `monitor-` |
+| 8 | Advanced Features | LOW | `advanced-` |
+
+## How to Use
+
+Read individual rule files for detailed explanations and SQL examples:
+
+```
+references/query-missing-indexes.md
+references/query-partial-indexes.md
+references/_sections.md
+```
+
+Each rule file contains:
+- Brief explanation of why it matters
+- Incorrect SQL example with explanation
+- Correct SQL example with explanation
+- Optional EXPLAIN output or metrics
+- Additional context and references
+- Supabase-specific notes (when applicable)
+
+## References
+
+- https://www.postgresql.org/docs/current/
+- https://supabase.com/docs
+- https://wiki.postgresql.org/wiki/Performance_Optimization
+- https://supabase.com/docs/guides/database/overview
+- https://supabase.com/docs/guides/auth/row-level-security

--- a/.agents/skills/supabase-postgres-best-practices/references/_contributing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_contributing.md
@@ -1,0 +1,170 @@
+# Writing Guidelines for Postgres References
+
+This document provides guidelines for creating effective Postgres best
+practice references that work well with AI agents and LLMs.
+
+## Key Principles
+
+### 1. Concrete Transformation Patterns
+
+Show exact SQL rewrites. Avoid philosophical advice.
+
+**Good:** "Use `WHERE id = ANY(ARRAY[...])` instead of
+`WHERE id IN (SELECT ...)`" **Bad:** "Design good schemas"
+
+### 2. Error-First Structure
+
+Always show the problematic pattern first, then the solution. This trains agents
+to recognize anti-patterns.
+
+```markdown
+**Incorrect (sequential queries):** [bad example]
+
+**Correct (batched query):** [good example]
+```
+
+### 3. Quantified Impact
+
+Include specific metrics. Helps agents prioritize fixes.
+
+**Good:** "10x faster queries", "50% smaller index", "Eliminates N+1" 
+**Bad:** "Faster", "Better", "More efficient"
+
+### 4. Self-Contained Examples
+
+Examples should be complete and runnable (or close to it). Include `CREATE TABLE`
+if context is needed.
+
+```sql
+-- Include table definition when needed for clarity
+CREATE TABLE users (
+  id bigint PRIMARY KEY,
+  email text NOT NULL,
+  deleted_at timestamptz
+);
+
+-- Now show the index
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+```
+
+### 5. Semantic Naming
+
+Use meaningful table/column names. Names carry intent for LLMs.
+
+**Good:** `users`, `email`, `created_at`, `is_active`
+**Bad:** `table1`, `col1`, `field`, `flag`
+
+---
+
+## Code Example Standards
+
+### SQL Formatting
+
+```sql
+-- Use lowercase keywords, clear formatting
+CREATE INDEX CONCURRENTLY users_email_idx
+  ON users(email)
+  WHERE deleted_at IS NULL;
+
+-- Not cramped or ALL CAPS
+CREATE INDEX CONCURRENTLY USERS_EMAIL_IDX ON USERS(EMAIL) WHERE DELETED_AT IS NULL;
+```
+
+### Comments
+
+- Explain _why_, not _what_
+- Highlight performance implications
+- Point out common pitfalls
+
+### Language Tags
+
+- `sql` - Standard SQL queries
+- `plpgsql` - Stored procedures/functions
+- `typescript` - Application code (when needed)
+- `python` - Application code (when needed)
+
+---
+
+## When to Include Application Code
+
+**Default: SQL Only**
+
+Most references should focus on pure SQL patterns. This keeps examples portable.
+
+**Include Application Code When:**
+
+- Connection pooling configuration
+- Transaction management in application context
+- ORM anti-patterns (N+1 in Prisma/TypeORM)
+- Prepared statement usage
+
+**Format for Mixed Examples:**
+
+````markdown
+**Incorrect (N+1 in application):**
+
+```typescript
+for (const user of users) {
+  const posts = await db.query("SELECT * FROM posts WHERE user_id = $1", [
+    user.id,
+  ]);
+}
+```
+````
+
+**Correct (batch query):**
+
+```typescript
+const posts = await db.query("SELECT * FROM posts WHERE user_id = ANY($1)", [
+  userIds,
+]);
+```
+
+---
+
+## Impact Level Guidelines
+
+| Level | Improvement | Use When |
+|-------|-------------|----------|
+| **CRITICAL** | 10-100x | Missing indexes, connection exhaustion, sequential scans on large tables |
+| **HIGH** | 5-20x | Wrong index types, poor partitioning, missing covering indexes |
+| **MEDIUM-HIGH** | 2-5x | N+1 queries, inefficient pagination, RLS optimization |
+| **MEDIUM** | 1.5-3x | Redundant indexes, query plan instability |
+| **LOW-MEDIUM** | 1.2-2x | VACUUM tuning, configuration tweaks |
+| **LOW** | Incremental | Advanced patterns, edge cases |
+
+---
+
+## Reference Standards
+
+**Primary Sources:**
+
+- Official Postgres documentation
+- Supabase documentation
+- Postgres wiki
+- Established blogs (2ndQuadrant, Crunchy Data)
+
+**Format:**
+
+```markdown
+Reference:
+[Postgres Indexes](https://www.postgresql.org/docs/current/indexes.html)
+```
+
+---
+
+## Review Checklist
+
+Before submitting a reference:
+
+- [ ] Title is clear and action-oriented
+- [ ] Impact level matches the performance gain
+- [ ] impactDescription includes quantification
+- [ ] Explanation is concise (1-2 sentences)
+- [ ] Has at least 1 **Incorrect** SQL example
+- [ ] Has at least 1 **Correct** SQL example
+- [ ] SQL uses semantic naming
+- [ ] Comments explain _why_, not _what_
+- [ ] Trade-offs mentioned if applicable
+- [ ] Reference links included
+- [ ] `pnpm test` passes

--- a/.agents/skills/supabase-postgres-best-practices/references/_sections.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_sections.md
@@ -1,0 +1,39 @@
+# Section Definitions
+
+This file defines the rule categories for Postgres best practices. Rules are automatically assigned to sections based on their filename prefix.
+
+Take the examples below as pure demonstrative. Replace each section with the actual rule categories for Postgres best practices.
+
+---
+
+## 1. Query Performance (query)
+**Impact:** CRITICAL
+**Description:** Slow queries, missing indexes, inefficient query plans. The most common source of Postgres performance issues.
+
+## 2. Connection Management (conn)
+**Impact:** CRITICAL
+**Description:** Connection pooling, limits, and serverless strategies. Critical for applications with high concurrency or serverless deployments.
+
+## 3. Security & RLS (security)
+**Impact:** CRITICAL
+**Description:** Row-Level Security policies, privilege management, and authentication patterns.
+
+## 4. Schema Design (schema)
+**Impact:** HIGH
+**Description:** Table design, index strategies, partitioning, and data type selection. Foundation for long-term performance.
+
+## 5. Concurrency & Locking (lock)
+**Impact:** MEDIUM-HIGH
+**Description:** Transaction management, isolation levels, deadlock prevention, and lock contention patterns.
+
+## 6. Data Access Patterns (data)
+**Impact:** MEDIUM
+**Description:** N+1 query elimination, batch operations, cursor-based pagination, and efficient data fetching.
+
+## 7. Monitoring & Diagnostics (monitor)
+**Impact:** LOW-MEDIUM
+**Description:** Using pg_stat_statements, EXPLAIN ANALYZE, metrics collection, and performance diagnostics.
+
+## 8. Advanced Features (advanced)
+**Impact:** LOW
+**Description:** Full-text search, JSONB optimization, PostGIS, extensions, and advanced Postgres features.

--- a/.agents/skills/supabase-postgres-best-practices/references/_template.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/_template.md
@@ -1,0 +1,34 @@
+---
+title: Clear, Action-Oriented Title (e.g., "Use Partial Indexes for Filtered Queries")
+impact: MEDIUM
+impactDescription: 5-20x query speedup for filtered queries
+tags: indexes, query-optimization, performance
+---
+
+## [Rule Title]
+
+[1-2 sentence explanation of the problem and why it matters. Focus on performance impact.]
+
+**Incorrect (describe the problem):**
+
+```sql
+-- Comment explaining what makes this slow/problematic
+CREATE INDEX users_email_idx ON users(email);
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- This scans deleted records unnecessarily
+```
+
+**Correct (describe the solution):**
+
+```sql
+-- Comment explaining why this is better
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- Only indexes active users, 10x smaller index, faster queries
+```
+
+[Optional: Additional context, edge cases, or trade-offs]
+
+Reference: [Postgres Docs](https://www.postgresql.org/docs/current/)

--- a/.agents/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
@@ -1,0 +1,55 @@
+---
+title: Use tsvector for Full-Text Search
+impact: MEDIUM
+impactDescription: 100x faster than LIKE, with ranking support
+tags: full-text-search, tsvector, gin, search
+---
+
+## Use tsvector for Full-Text Search
+
+LIKE with wildcards can't use indexes. Full-text search with tsvector is orders of magnitude faster.
+
+**Incorrect (LIKE pattern matching):**
+
+```sql
+-- Cannot use index, scans all rows
+select * from articles where content like '%postgresql%';
+
+-- Case-insensitive makes it worse
+select * from articles where lower(content) like '%postgresql%';
+```
+
+**Correct (full-text search with tsvector):**
+
+```sql
+-- Add tsvector column and index
+alter table articles add column search_vector tsvector
+  generated always as (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(content,''))) stored;
+
+create index articles_search_idx on articles using gin (search_vector);
+
+-- Fast full-text search
+select * from articles
+where search_vector @@ to_tsquery('english', 'postgresql & performance');
+
+-- With ranking
+select *, ts_rank(search_vector, query) as rank
+from articles, to_tsquery('english', 'postgresql') query
+where search_vector @@ query
+order by rank desc;
+```
+
+Search multiple terms:
+
+```sql
+-- AND: both terms required
+to_tsquery('postgresql & performance')
+
+-- OR: either term
+to_tsquery('postgresql | mysql')
+
+-- Prefix matching
+to_tsquery('post:*')
+```
+
+Reference: [Full Text Search](https://supabase.com/docs/guides/database/full-text-search)

--- a/.agents/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
@@ -1,0 +1,49 @@
+---
+title: Index JSONB Columns for Efficient Querying
+impact: MEDIUM
+impactDescription: 10-100x faster JSONB queries with proper indexing
+tags: jsonb, gin, indexes, json
+---
+
+## Index JSONB Columns for Efficient Querying
+
+JSONB queries without indexes scan the entire table. Use GIN indexes for containment queries.
+
+**Incorrect (no index on JSONB):**
+
+```sql
+create table products (
+  id bigint primary key,
+  attributes jsonb
+);
+
+-- Full table scan for every query
+select * from products where attributes @> '{"color": "red"}';
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+**Correct (GIN index for JSONB):**
+
+```sql
+-- GIN index for containment operators (@>, ?, ?&, ?|)
+create index products_attrs_gin on products using gin (attributes);
+
+-- Now containment queries use the index
+select * from products where attributes @> '{"color": "red"}';
+
+-- For specific key lookups, use expression index
+create index products_brand_idx on products ((attributes->>'brand'));
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+Choose the right operator class:
+
+```sql
+-- jsonb_ops (default): supports all operators, larger index
+create index idx1 on products using gin (attributes);
+
+-- jsonb_path_ops: only @> operator, but 2-3x smaller index
+create index idx2 on products using gin (attributes jsonb_path_ops);
+```
+
+Reference: [JSONB Indexes](https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
@@ -1,0 +1,46 @@
+---
+title: Configure Idle Connection Timeouts
+impact: HIGH
+impactDescription: Reclaim 30-50% of connection slots from idle clients
+tags: connections, timeout, idle, resource-management
+---
+
+## Configure Idle Connection Timeouts
+
+Idle connections waste resources. Configure timeouts to automatically reclaim them.
+
+**Incorrect (connections held indefinitely):**
+
+```sql
+-- No timeout configured
+show idle_in_transaction_session_timeout;  -- 0 (disabled)
+
+-- Connections stay open forever, even when idle
+select pid, state, state_change, query
+from pg_stat_activity
+where state = 'idle in transaction';
+-- Shows transactions idle for hours, holding locks
+```
+
+**Correct (automatic cleanup of idle connections):**
+
+```sql
+-- Terminate connections idle in transaction after 30 seconds
+alter system set idle_in_transaction_session_timeout = '30s';
+
+-- Terminate completely idle connections after 10 minutes
+alter system set idle_session_timeout = '10min';
+
+-- Reload configuration
+select pg_reload_conf();
+```
+
+For pooled connections, configure at the pooler level:
+
+```ini
+# pgbouncer.ini
+server_idle_timeout = 60
+client_idle_timeout = 300
+```
+
+Reference: [Connection Timeouts](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-limits.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-limits.md
@@ -1,0 +1,44 @@
+---
+title: Set Appropriate Connection Limits
+impact: CRITICAL
+impactDescription: Prevent database crashes and memory exhaustion
+tags: connections, max-connections, limits, stability
+---
+
+## Set Appropriate Connection Limits
+
+Too many connections exhaust memory and degrade performance. Set limits based on available resources.
+
+**Incorrect (unlimited or excessive connections):**
+
+```sql
+-- Default max_connections = 100, but often increased blindly
+show max_connections;  -- 500 (way too high for 4GB RAM)
+
+-- Each connection uses 1-3MB RAM
+-- 500 connections * 2MB = 1GB just for connections!
+-- Out of memory errors under load
+```
+
+**Correct (calculate based on resources):**
+
+```sql
+-- Formula: max_connections = (RAM in MB / 5MB per connection) - reserved
+-- For 4GB RAM: (4096 / 5) - 10 = ~800 theoretical max
+-- But practically, 100-200 is better for query performance
+
+-- Recommended settings for 4GB RAM
+alter system set max_connections = 100;
+
+-- Also set work_mem appropriately
+-- work_mem * max_connections should not exceed 25% of RAM
+alter system set work_mem = '8MB';  -- 8MB * 100 = 800MB max
+```
+
+Monitor connection usage:
+
+```sql
+select count(*), state from pg_stat_activity group by state;
+```
+
+Reference: [Database Connections](https://supabase.com/docs/guides/platform/performance#connection-management)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-pooling.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-pooling.md
@@ -1,0 +1,41 @@
+---
+title: Use Connection Pooling for All Applications
+impact: CRITICAL
+impactDescription: Handle 10-100x more concurrent users
+tags: connection-pooling, pgbouncer, performance, scalability
+---
+
+## Use Connection Pooling for All Applications
+
+Postgres connections are expensive (1-3MB RAM each). Without pooling, applications exhaust connections under load.
+
+**Incorrect (new connection per request):**
+
+```sql
+-- Each request creates a new connection
+-- Application code: db.connect() per request
+-- Result: 500 concurrent users = 500 connections = crashed database
+
+-- Check current connections
+select count(*) from pg_stat_activity;  -- 487 connections!
+```
+
+**Correct (connection pooling):**
+
+```sql
+-- Use a pooler like PgBouncer between app and database
+-- Application connects to pooler, pooler reuses a small pool to Postgres
+
+-- Configure pool_size based on: (CPU cores * 2) + spindle_count
+-- Example for 4 cores: pool_size = 10
+
+-- Result: 500 concurrent users share 10 actual connections
+select count(*) from pg_stat_activity;  -- 10 connections
+```
+
+Pool modes:
+
+- **Transaction mode**: connection returned after each transaction (best for most apps)
+- **Session mode**: connection held for entire session (needed for prepared statements, temp tables)
+
+Reference: [Connection Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler)

--- a/.agents/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
@@ -1,0 +1,46 @@
+---
+title: Use Prepared Statements Correctly with Pooling
+impact: HIGH
+impactDescription: Avoid prepared statement conflicts in pooled environments
+tags: prepared-statements, connection-pooling, transaction-mode
+---
+
+## Use Prepared Statements Correctly with Pooling
+
+Prepared statements are tied to individual database connections. In transaction-mode pooling, connections are shared, causing conflicts.
+
+**Incorrect (named prepared statements with transaction pooling):**
+
+```sql
+-- Named prepared statement
+prepare get_user as select * from users where id = $1;
+
+-- In transaction mode pooling, next request may get different connection
+execute get_user(123);
+-- ERROR: prepared statement "get_user" does not exist
+```
+
+**Correct (use unnamed statements or session mode):**
+
+```sql
+-- Option 1: Use unnamed prepared statements (most ORMs do this automatically)
+-- The query is prepared and executed in a single protocol message
+
+-- Option 2: Deallocate after use in transaction mode
+prepare get_user as select * from users where id = $1;
+execute get_user(123);
+deallocate get_user;
+
+-- Option 3: Use session mode pooling (port 5432 vs 6543)
+-- Connection is held for entire session, prepared statements persist
+```
+
+Check your driver settings:
+
+```sql
+-- Many drivers use prepared statements by default
+-- Node.js pg: { prepare: false } to disable
+-- JDBC: prepareThreshold=0 to disable
+```
+
+Reference: [Prepared Statements with Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pool-modes)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
@@ -1,0 +1,54 @@
+---
+title: Batch INSERT Statements for Bulk Data
+impact: MEDIUM
+impactDescription: 10-50x faster bulk inserts
+tags: batch, insert, bulk, performance, copy
+---
+
+## Batch INSERT Statements for Bulk Data
+
+Individual INSERT statements have high overhead. Batch multiple rows in single statements or use COPY.
+
+**Incorrect (individual inserts):**
+
+```sql
+-- Each insert is a separate transaction and round trip
+insert into events (user_id, action) values (1, 'click');
+insert into events (user_id, action) values (1, 'view');
+insert into events (user_id, action) values (2, 'click');
+-- ... 1000 more individual inserts
+
+-- 1000 inserts = 1000 round trips = slow
+```
+
+**Correct (batch insert):**
+
+```sql
+-- Multiple rows in single statement
+insert into events (user_id, action) values
+  (1, 'click'),
+  (1, 'view'),
+  (2, 'click'),
+  -- ... up to ~1000 rows per batch
+  (999, 'view');
+
+-- One round trip for 1000 rows
+```
+
+For large imports, use COPY:
+
+```sql
+-- COPY is fastest for bulk loading
+copy events (user_id, action, created_at)
+from '/path/to/data.csv'
+with (format csv, header true);
+
+-- Or from stdin in application
+copy events (user_id, action) from stdin with (format csv);
+1,click
+1,view
+2,click
+\.
+```
+
+Reference: [COPY](https://www.postgresql.org/docs/current/sql-copy.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
@@ -1,0 +1,53 @@
+---
+title: Eliminate N+1 Queries with Batch Loading
+impact: MEDIUM-HIGH
+impactDescription: 10-100x fewer database round trips
+tags: n-plus-one, batch, performance, queries
+---
+
+## Eliminate N+1 Queries with Batch Loading
+
+N+1 queries execute one query per item in a loop. Batch them into a single query using arrays or JOINs.
+
+**Incorrect (N+1 queries):**
+
+```sql
+-- First query: get all users
+select id from users where active = true;  -- Returns 100 IDs
+
+-- Then N queries, one per user
+select * from orders where user_id = 1;
+select * from orders where user_id = 2;
+select * from orders where user_id = 3;
+-- ... 97 more queries!
+
+-- Total: 101 round trips to database
+```
+
+**Correct (single batch query):**
+
+```sql
+-- Collect IDs and query once with ANY
+select * from orders where user_id = any(array[1, 2, 3, ...]);
+
+-- Or use JOIN instead of loop
+select u.id, u.name, o.*
+from users u
+left join orders o on o.user_id = u.id
+where u.active = true;
+
+-- Total: 1 round trip
+```
+
+Application pattern:
+
+```sql
+-- Instead of looping in application code:
+-- for user in users: db.query("SELECT * FROM orders WHERE user_id = $1", user.id)
+
+-- Pass array parameter:
+select * from orders where user_id = any($1::bigint[]);
+-- Application passes: [1, 2, 3, 4, 5, ...]
+```
+
+Reference: [N+1 Query Problem](https://supabase.com/docs/guides/database/query-optimization)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-pagination.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-pagination.md
@@ -1,0 +1,50 @@
+---
+title: Use Cursor-Based Pagination Instead of OFFSET
+impact: MEDIUM-HIGH
+impactDescription: Consistent O(1) performance regardless of page depth
+tags: pagination, cursor, keyset, offset, performance
+---
+
+## Use Cursor-Based Pagination Instead of OFFSET
+
+OFFSET-based pagination scans all skipped rows, getting slower on deeper pages. Cursor pagination is O(1).
+
+**Incorrect (OFFSET pagination):**
+
+```sql
+-- Page 1: scans 20 rows
+select * from products order by id limit 20 offset 0;
+
+-- Page 100: scans 2000 rows to skip 1980
+select * from products order by id limit 20 offset 1980;
+
+-- Page 10000: scans 200,000 rows!
+select * from products order by id limit 20 offset 199980;
+```
+
+**Correct (cursor/keyset pagination):**
+
+```sql
+-- Page 1: get first 20
+select * from products order by id limit 20;
+-- Application stores last_id = 20
+
+-- Page 2: start after last ID
+select * from products where id > 20 order by id limit 20;
+-- Uses index, always fast regardless of page depth
+
+-- Page 10000: same speed as page 1
+select * from products where id > 199980 order by id limit 20;
+```
+
+For multi-column sorting:
+
+```sql
+-- Cursor must include all sort columns
+select * from products
+where (created_at, id) > ('2024-01-15 10:00:00', 12345)
+order by created_at, id
+limit 20;
+```
+
+Reference: [Pagination](https://supabase.com/docs/guides/database/pagination)

--- a/.agents/skills/supabase-postgres-best-practices/references/data-upsert.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/data-upsert.md
@@ -1,0 +1,50 @@
+---
+title: Use UPSERT for Insert-or-Update Operations
+impact: MEDIUM
+impactDescription: Atomic operation, eliminates race conditions
+tags: upsert, on-conflict, insert, update
+---
+
+## Use UPSERT for Insert-or-Update Operations
+
+Using separate SELECT-then-INSERT/UPDATE creates race conditions. Use INSERT ... ON CONFLICT for atomic upserts.
+
+**Incorrect (check-then-insert race condition):**
+
+```sql
+-- Race condition: two requests check simultaneously
+select * from settings where user_id = 123 and key = 'theme';
+-- Both find nothing
+
+-- Both try to insert
+insert into settings (user_id, key, value) values (123, 'theme', 'dark');
+-- One succeeds, one fails with duplicate key error!
+```
+
+**Correct (atomic UPSERT):**
+
+```sql
+-- Single atomic operation
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value, updated_at = now();
+
+-- Returns the inserted/updated row
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value
+returning *;
+```
+
+Insert-or-ignore pattern:
+
+```sql
+-- Insert only if not exists (no update)
+insert into page_views (page_id, user_id)
+values (1, 123)
+on conflict (page_id, user_id) do nothing;
+```
+
+Reference: [INSERT ON CONFLICT](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-advisory.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-advisory.md
@@ -1,0 +1,56 @@
+---
+title: Use Advisory Locks for Application-Level Locking
+impact: MEDIUM
+impactDescription: Efficient coordination without row-level lock overhead
+tags: advisory-locks, coordination, application-locks
+---
+
+## Use Advisory Locks for Application-Level Locking
+
+Advisory locks provide application-level coordination without requiring database rows to lock.
+
+**Incorrect (creating rows just for locking):**
+
+```sql
+-- Creating dummy rows to lock on
+create table resource_locks (
+  resource_name text primary key
+);
+
+insert into resource_locks values ('report_generator');
+
+-- Lock by selecting the row
+select * from resource_locks where resource_name = 'report_generator' for update;
+```
+
+**Correct (advisory locks):**
+
+```sql
+-- Session-level advisory lock (released on disconnect or unlock)
+select pg_advisory_lock(hashtext('report_generator'));
+-- ... do exclusive work ...
+select pg_advisory_unlock(hashtext('report_generator'));
+
+-- Transaction-level lock (released on commit/rollback)
+begin;
+select pg_advisory_xact_lock(hashtext('daily_report'));
+-- ... do work ...
+commit;  -- Lock automatically released
+```
+
+Try-lock for non-blocking operations:
+
+```sql
+-- Returns immediately with true/false instead of waiting
+select pg_try_advisory_lock(hashtext('resource_name'));
+
+-- Use in application
+if (acquired) {
+  -- Do work
+  select pg_advisory_unlock(hashtext('resource_name'));
+} else {
+  -- Skip or retry later
+}
+```
+
+Reference: [Advisory Locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
@@ -1,0 +1,68 @@
+---
+title: Prevent Deadlocks with Consistent Lock Ordering
+impact: MEDIUM-HIGH
+impactDescription: Eliminate deadlock errors, improve reliability
+tags: deadlocks, locking, transactions, ordering
+---
+
+## Prevent Deadlocks with Consistent Lock Ordering
+
+Deadlocks occur when transactions lock resources in different orders. Always
+acquire locks in a consistent order.
+
+**Incorrect (inconsistent lock ordering):**
+
+```sql
+-- Transaction A                    -- Transaction B
+begin;                              begin;
+update accounts                     update accounts
+set balance = balance - 100         set balance = balance - 50
+where id = 1;                       where id = 2;  -- B locks row 2
+
+update accounts                     update accounts
+set balance = balance + 100         set balance = balance + 50
+where id = 2;  -- A waits for B     where id = 1;  -- B waits for A
+
+-- DEADLOCK! Both waiting for each other
+```
+
+**Correct (lock rows in consistent order first):**
+
+```sql
+-- Explicitly acquire locks in ID order before updating
+begin;
+select * from accounts where id in (1, 2) order by id for update;
+
+-- Now perform updates in any order - locks already held
+update accounts set balance = balance - 100 where id = 1;
+update accounts set balance = balance + 100 where id = 2;
+commit;
+```
+
+Alternative: use a single statement to update atomically:
+
+```sql
+-- Single statement acquires all locks atomically
+begin;
+update accounts
+set balance = balance + case id
+  when 1 then -100
+  when 2 then 100
+end
+where id in (1, 2);
+commit;
+```
+
+Detect deadlocks in logs:
+
+```sql
+-- Check for recent deadlocks
+select * from pg_stat_database where deadlocks > 0;
+
+-- Enable deadlock logging
+set log_lock_waits = on;
+set deadlock_timeout = '1s';
+```
+
+Reference:
+[Deadlocks](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
@@ -1,0 +1,50 @@
+---
+title: Keep Transactions Short to Reduce Lock Contention
+impact: MEDIUM-HIGH
+impactDescription: 3-5x throughput improvement, fewer deadlocks
+tags: transactions, locking, contention, performance
+---
+
+## Keep Transactions Short to Reduce Lock Contention
+
+Long-running transactions hold locks that block other queries. Keep transactions as short as possible.
+
+**Incorrect (long transaction with external calls):**
+
+```sql
+begin;
+select * from orders where id = 1 for update;  -- Lock acquired
+
+-- Application makes HTTP call to payment API (2-5 seconds)
+-- Other queries on this row are blocked!
+
+update orders set status = 'paid' where id = 1;
+commit;  -- Lock held for entire duration
+```
+
+**Correct (minimal transaction scope):**
+
+```sql
+-- Validate data and call APIs outside transaction
+-- Application: response = await paymentAPI.charge(...)
+
+-- Only hold lock for the actual update
+begin;
+update orders
+set status = 'paid', payment_id = $1
+where id = $2 and status = 'pending'
+returning *;
+commit;  -- Lock held for milliseconds
+```
+
+Use `statement_timeout` to prevent runaway transactions:
+
+```sql
+-- Abort queries running longer than 30 seconds
+set statement_timeout = '30s';
+
+-- Or per-session
+set local statement_timeout = '5s';
+```
+
+Reference: [Transaction Management](https://www.postgresql.org/docs/current/tutorial-transactions.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
@@ -1,0 +1,54 @@
+---
+title: Use SKIP LOCKED for Non-Blocking Queue Processing
+impact: MEDIUM-HIGH
+impactDescription: 10x throughput for worker queues
+tags: skip-locked, queue, workers, concurrency
+---
+
+## Use SKIP LOCKED for Non-Blocking Queue Processing
+
+When multiple workers process a queue, SKIP LOCKED allows workers to process different rows without waiting.
+
+**Incorrect (workers block each other):**
+
+```sql
+-- Worker 1 and Worker 2 both try to get next job
+begin;
+select * from jobs where status = 'pending' order by created_at limit 1 for update;
+-- Worker 2 waits for Worker 1's lock to release!
+```
+
+**Correct (SKIP LOCKED for parallel processing):**
+
+```sql
+-- Each worker skips locked rows and gets the next available
+begin;
+select * from jobs
+where status = 'pending'
+order by created_at
+limit 1
+for update skip locked;
+
+-- Worker 1 gets job 1, Worker 2 gets job 2 (no waiting)
+
+update jobs set status = 'processing' where id = $1;
+commit;
+```
+
+Complete queue pattern:
+
+```sql
+-- Atomic claim-and-update in one statement
+update jobs
+set status = 'processing', worker_id = $1, started_at = now()
+where id = (
+  select id from jobs
+  where status = 'pending'
+  order by created_at
+  limit 1
+  for update skip locked
+)
+returning *;
+```
+
+Reference: [SELECT FOR UPDATE SKIP LOCKED](https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
@@ -1,0 +1,45 @@
+---
+title: Use EXPLAIN ANALYZE to Diagnose Slow Queries
+impact: LOW-MEDIUM
+impactDescription: Identify exact bottlenecks in query execution
+tags: explain, analyze, diagnostics, query-plan
+---
+
+## Use EXPLAIN ANALYZE to Diagnose Slow Queries
+
+EXPLAIN ANALYZE executes the query and shows actual timings, revealing the true performance bottlenecks.
+
+**Incorrect (guessing at performance issues):**
+
+```sql
+-- Query is slow, but why?
+select * from orders where customer_id = 123 and status = 'pending';
+-- "It must be missing an index" - but which one?
+```
+
+**Correct (use EXPLAIN ANALYZE):**
+
+```sql
+explain (analyze, buffers, format text)
+select * from orders where customer_id = 123 and status = 'pending';
+
+-- Output reveals the issue:
+-- Seq Scan on orders (cost=0.00..25000.00 rows=50 width=100) (actual time=0.015..450.123 rows=50 loops=1)
+--   Filter: ((customer_id = 123) AND (status = 'pending'::text))
+--   Rows Removed by Filter: 999950
+--   Buffers: shared hit=5000 read=15000
+-- Planning Time: 0.150 ms
+-- Execution Time: 450.500 ms
+```
+
+Key things to look for:
+
+```sql
+-- Seq Scan on large tables = missing index
+-- Rows Removed by Filter = poor selectivity or missing index
+-- Buffers: read >> hit = data not cached, needs more memory
+-- Nested Loop with high loops = consider different join strategy
+-- Sort Method: external merge = work_mem too low
+```
+
+Reference: [EXPLAIN](https://supabase.com/docs/guides/database/inspect)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
@@ -1,0 +1,55 @@
+---
+title: Enable pg_stat_statements for Query Analysis
+impact: LOW-MEDIUM
+impactDescription: Identify top resource-consuming queries
+tags: pg-stat-statements, monitoring, statistics, performance
+---
+
+## Enable pg_stat_statements for Query Analysis
+
+pg_stat_statements tracks execution statistics for all queries, helping identify slow and frequent queries.
+
+**Incorrect (no visibility into query patterns):**
+
+```sql
+-- Database is slow, but which queries are the problem?
+-- No way to know without pg_stat_statements
+```
+
+**Correct (enable and query pg_stat_statements):**
+
+```sql
+-- Enable the extension
+create extension if not exists pg_stat_statements;
+
+-- Find slowest queries by total time
+select
+  calls,
+  round(total_exec_time::numeric, 2) as total_time_ms,
+  round(mean_exec_time::numeric, 2) as mean_time_ms,
+  query
+from pg_stat_statements
+order by total_exec_time desc
+limit 10;
+
+-- Find most frequent queries
+select calls, query
+from pg_stat_statements
+order by calls desc
+limit 10;
+
+-- Reset statistics after optimization
+select pg_stat_statements_reset();
+```
+
+Key metrics to monitor:
+
+```sql
+-- Queries with high mean time (candidates for optimization)
+select query, mean_exec_time, calls
+from pg_stat_statements
+where mean_exec_time > 100  -- > 100ms average
+order by mean_exec_time desc;
+```
+
+Reference: [pg_stat_statements](https://supabase.com/docs/guides/database/extensions/pg_stat_statements)

--- a/.agents/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
@@ -1,0 +1,55 @@
+---
+title: Maintain Table Statistics with VACUUM and ANALYZE
+impact: MEDIUM
+impactDescription: 2-10x better query plans with accurate statistics
+tags: vacuum, analyze, statistics, maintenance, autovacuum
+---
+
+## Maintain Table Statistics with VACUUM and ANALYZE
+
+Outdated statistics cause the query planner to make poor decisions. VACUUM reclaims space, ANALYZE updates statistics.
+
+**Incorrect (stale statistics):**
+
+```sql
+-- Table has 1M rows but stats say 1000
+-- Query planner chooses wrong strategy
+explain select * from orders where status = 'pending';
+-- Shows: Seq Scan (because stats show small table)
+-- Actually: Index Scan would be much faster
+```
+
+**Correct (maintain fresh statistics):**
+
+```sql
+-- Manually analyze after large data changes
+analyze orders;
+
+-- Analyze specific columns used in WHERE clauses
+analyze orders (status, created_at);
+
+-- Check when tables were last analyzed
+select
+  relname,
+  last_vacuum,
+  last_autovacuum,
+  last_analyze,
+  last_autoanalyze
+from pg_stat_user_tables
+order by last_analyze nulls first;
+```
+
+Autovacuum tuning for busy tables:
+
+```sql
+-- Increase frequency for high-churn tables
+alter table orders set (
+  autovacuum_vacuum_scale_factor = 0.05,     -- Vacuum at 5% dead tuples (default 20%)
+  autovacuum_analyze_scale_factor = 0.02     -- Analyze at 2% changes (default 10%)
+);
+
+-- Check autovacuum status
+select * from pg_stat_progress_vacuum;
+```
+
+Reference: [VACUUM](https://supabase.com/docs/guides/database/database-size#vacuum-operations)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
@@ -1,0 +1,44 @@
+---
+title: Create Composite Indexes for Multi-Column Queries
+impact: HIGH
+impactDescription: 5-10x faster multi-column queries
+tags: indexes, composite-index, multi-column, query-optimization
+---
+
+## Create Composite Indexes for Multi-Column Queries
+
+When queries filter on multiple columns, a composite index is more efficient than separate single-column indexes.
+
+**Incorrect (separate indexes require bitmap scan):**
+
+```sql
+-- Two separate indexes
+create index orders_status_idx on orders (status);
+create index orders_created_idx on orders (created_at);
+
+-- Query must combine both indexes (slower)
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Correct (composite index):**
+
+```sql
+-- Single composite index (leftmost column first for equality checks)
+create index orders_status_created_idx on orders (status, created_at);
+
+-- Query uses one efficient index scan
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Column order matters** - place equality columns first, range columns last:
+
+```sql
+-- Good: status (=) before created_at (>)
+create index idx on orders (status, created_at);
+
+-- Works for: WHERE status = 'pending'
+-- Works for: WHERE status = 'pending' AND created_at > '2024-01-01'
+-- Does NOT work for: WHERE created_at > '2024-01-01' (leftmost prefix rule)
+```
+
+Reference: [Multicolumn Indexes](https://www.postgresql.org/docs/current/indexes-multicolumn.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
@@ -1,0 +1,40 @@
+---
+title: Use Covering Indexes to Avoid Table Lookups
+impact: MEDIUM-HIGH
+impactDescription: 2-5x faster queries by eliminating heap fetches
+tags: indexes, covering-index, include, index-only-scan
+---
+
+## Use Covering Indexes to Avoid Table Lookups
+
+Covering indexes include all columns needed by a query, enabling index-only scans that skip the table entirely.
+
+**Incorrect (index scan + heap fetch):**
+
+```sql
+create index users_email_idx on users (email);
+
+-- Must fetch name and created_at from table heap
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+**Correct (index-only scan with INCLUDE):**
+
+```sql
+-- Include non-searchable columns in the index
+create index users_email_idx on users (email) include (name, created_at);
+
+-- All columns served from index, no table access needed
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+Use INCLUDE for columns you SELECT but don't filter on:
+
+```sql
+-- Searching by status, but also need customer_id and total
+create index orders_status_idx on orders (status) include (customer_id, total);
+
+select status, customer_id, total from orders where status = 'shipped';
+```
+
+Reference: [Index-Only Scans](https://www.postgresql.org/docs/current/indexes-index-only-scans.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-index-types.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-index-types.md
@@ -1,0 +1,48 @@
+---
+title: Choose the Right Index Type for Your Data
+impact: HIGH
+impactDescription: 10-100x improvement with correct index type
+tags: indexes, btree, gin, gist, brin, hash, index-types
+---
+
+## Choose the Right Index Type for Your Data
+
+Different index types excel at different query patterns. The default B-tree isn't always optimal.
+
+**Incorrect (B-tree for JSONB containment):**
+
+```sql
+-- B-tree cannot optimize containment operators
+create index products_attrs_idx on products (attributes);
+select * from products where attributes @> '{"color": "red"}';
+-- Full table scan - B-tree doesn't support @> operator
+```
+
+**Correct (GIN for JSONB):**
+
+```sql
+-- GIN supports @>, ?, ?&, ?| operators
+create index products_attrs_idx on products using gin (attributes);
+select * from products where attributes @> '{"color": "red"}';
+```
+
+Index type guide:
+
+```sql
+-- B-tree (default): =, <, >, BETWEEN, IN, IS NULL
+create index users_created_idx on users (created_at);
+
+-- GIN: arrays, JSONB, full-text search
+create index posts_tags_idx on posts using gin (tags);
+
+-- GiST: geometric data, range types, nearest-neighbor (KNN) queries
+create index locations_idx on places using gist (location);
+
+-- BRIN: large time-series tables (10-100x smaller)
+create index events_time_idx on events using brin (created_at);
+
+-- Hash: equality-only (slightly faster than B-tree for =)
+create index sessions_token_idx on sessions using hash (token);
+```
+
+Reference: [Index Types](https://www.postgresql.org/docs/current/indexes-types.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
@@ -1,0 +1,43 @@
+---
+title: Add Indexes on WHERE and JOIN Columns
+impact: CRITICAL
+impactDescription: 100-1000x faster queries on large tables
+tags: indexes, performance, sequential-scan, query-optimization
+---
+
+## Add Indexes on WHERE and JOIN Columns
+
+Queries filtering or joining on unindexed columns cause full table scans, which become exponentially slower as tables grow.
+
+**Incorrect (sequential scan on large table):**
+
+```sql
+-- No index on customer_id causes full table scan
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Seq Scan on orders (cost=0.00..25000.00 rows=100 width=85)
+```
+
+**Correct (index scan):**
+
+```sql
+-- Create index on frequently filtered column
+create index orders_customer_id_idx on orders (customer_id);
+
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Index Scan using orders_customer_id_idx (cost=0.42..8.44 rows=100 width=85)
+```
+
+For JOIN columns, always index the foreign key side:
+
+```sql
+-- Index the referencing column
+create index orders_customer_id_idx on orders (customer_id);
+
+select c.name, o.total
+from customers c
+join orders o on o.customer_id = c.id;
+```
+
+Reference: [Query Optimization](https://supabase.com/docs/guides/database/query-optimization)

--- a/.agents/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
@@ -1,0 +1,45 @@
+---
+title: Use Partial Indexes for Filtered Queries
+impact: HIGH
+impactDescription: 5-20x smaller indexes, faster writes and queries
+tags: indexes, partial-index, query-optimization, storage
+---
+
+## Use Partial Indexes for Filtered Queries
+
+Partial indexes only include rows matching a WHERE condition, making them smaller and faster when queries consistently filter on the same condition.
+
+**Incorrect (full index includes irrelevant rows):**
+
+```sql
+-- Index includes all rows, even soft-deleted ones
+create index users_email_idx on users (email);
+
+-- Query always filters active users
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+**Correct (partial index matches query filter):**
+
+```sql
+-- Index only includes active users
+create index users_active_email_idx on users (email)
+where deleted_at is null;
+
+-- Query uses the smaller, faster index
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+Common use cases for partial indexes:
+
+```sql
+-- Only pending orders (status rarely changes once completed)
+create index orders_pending_idx on orders (created_at)
+where status = 'pending';
+
+-- Only non-null values
+create index products_sku_idx on products (sku)
+where sku is not null;
+```
+
+Reference: [Partial Indexes](https://www.postgresql.org/docs/current/indexes-partial.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-constraints.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-constraints.md
@@ -1,0 +1,80 @@
+---
+title: Add Constraints Safely in Migrations
+impact: HIGH
+impactDescription: Prevents migration failures and enables idempotent schema changes
+tags: constraints, migrations, schema, alter-table
+---
+
+## Add Constraints Safely in Migrations
+
+PostgreSQL does not support `ADD CONSTRAINT IF NOT EXISTS`. Migrations using this syntax will fail.
+
+**Incorrect (causes syntax error):**
+
+```sql
+-- ERROR: syntax error at or near "not" (SQLSTATE 42601)
+alter table public.profiles
+add constraint if not exists profiles_birthchart_id_unique unique (birthchart_id);
+```
+
+**Correct (idempotent constraint creation):**
+
+```sql
+-- Use DO block to check before adding
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_unique'
+    and conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+    add constraint profiles_birthchart_id_unique unique (birthchart_id);
+  end if;
+end $$;
+```
+
+For all constraint types:
+
+```sql
+-- Check constraints
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'check_age_positive'
+  ) then
+    alter table users add constraint check_age_positive check (age > 0);
+  end if;
+end $$;
+
+-- Foreign keys
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_fkey'
+  ) then
+    alter table profiles
+    add constraint profiles_birthchart_id_fkey
+    foreign key (birthchart_id) references birthcharts(id);
+  end if;
+end $$;
+```
+
+Check if constraint exists:
+
+```sql
+-- Query to check constraint existence
+select conname, contype, pg_get_constraintdef(oid)
+from pg_constraint
+where conrelid = 'public.profiles'::regclass;
+
+-- contype values:
+-- 'p' = PRIMARY KEY
+-- 'f' = FOREIGN KEY
+-- 'u' = UNIQUE
+-- 'c' = CHECK
+```
+
+Reference: [Constraints](https://www.postgresql.org/docs/current/ddl-constraints.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-data-types.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-data-types.md
@@ -1,0 +1,46 @@
+---
+title: Choose Appropriate Data Types
+impact: HIGH
+impactDescription: 50% storage reduction, faster comparisons
+tags: data-types, schema, storage, performance
+---
+
+## Choose Appropriate Data Types
+
+Using the right data types reduces storage, improves query performance, and prevents bugs.
+
+**Incorrect (wrong data types):**
+
+```sql
+create table users (
+  id int,                    -- Will overflow at 2.1 billion
+  email varchar(255),        -- Unnecessary length limit
+  created_at timestamp,      -- Missing timezone info
+  is_active varchar(5),      -- String for boolean
+  price varchar(20)          -- String for numeric
+);
+```
+
+**Correct (appropriate data types):**
+
+```sql
+create table users (
+  id bigint generated always as identity primary key,  -- 9 quintillion max
+  email text,                     -- No artificial limit, same performance as varchar
+  created_at timestamptz,         -- Always store timezone-aware timestamps
+  is_active boolean default true, -- 1 byte vs variable string length
+  price numeric(10,2)             -- Exact decimal arithmetic
+);
+```
+
+Key guidelines:
+
+```sql
+-- IDs: use bigint, not int (future-proofing)
+-- Strings: use text, not varchar(n) unless constraint needed
+-- Time: use timestamptz, not timestamp
+-- Money: use numeric, not float (precision matters)
+-- Enums: use text with check constraint or create enum type
+```
+
+Reference: [Data Types](https://www.postgresql.org/docs/current/datatype.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
@@ -1,0 +1,59 @@
+---
+title: Index Foreign Key Columns
+impact: HIGH
+impactDescription: 10-100x faster JOINs and CASCADE operations
+tags: foreign-key, indexes, joins, schema
+---
+
+## Index Foreign Key Columns
+
+Postgres does not automatically index foreign key columns. Missing indexes cause slow JOINs and CASCADE operations.
+
+**Incorrect (unindexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- No index on customer_id!
+-- JOINs and ON DELETE CASCADE both require full table scan
+select * from orders where customer_id = 123;  -- Seq Scan
+delete from customers where id = 123;          -- Locks table, scans all orders
+```
+
+**Correct (indexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- Always index the FK column
+create index orders_customer_id_idx on orders (customer_id);
+
+-- Now JOINs and cascades are fast
+select * from orders where customer_id = 123;  -- Index Scan
+delete from customers where id = 123;          -- Uses index, fast cascade
+```
+
+Find missing FK indexes:
+
+```sql
+select
+  conrelid::regclass as table_name,
+  a.attname as fk_column
+from pg_constraint c
+join pg_attribute a on a.attrelid = c.conrelid and a.attnum = any(c.conkey)
+where c.contype = 'f'
+  and not exists (
+    select 1 from pg_index i
+    where i.indrelid = c.conrelid and a.attnum = any(i.indkey)
+  );
+```
+
+Reference: [Foreign Keys](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
@@ -1,0 +1,55 @@
+---
+title: Use Lowercase Identifiers for Compatibility
+impact: MEDIUM
+impactDescription: Avoid case-sensitivity bugs with tools, ORMs, and AI assistants
+tags: naming, identifiers, case-sensitivity, schema, conventions
+---
+
+## Use Lowercase Identifiers for Compatibility
+
+PostgreSQL folds unquoted identifiers to lowercase. Quoted mixed-case identifiers require quotes forever and cause issues with tools, ORMs, and AI assistants that may not recognize them.
+
+**Incorrect (mixed-case identifiers):**
+
+```sql
+-- Quoted identifiers preserve case but require quotes everywhere
+CREATE TABLE "Users" (
+  "userId" bigint PRIMARY KEY,
+  "firstName" text,
+  "lastName" text
+);
+
+-- Must always quote or queries fail
+SELECT "firstName" FROM "Users" WHERE "userId" = 1;
+
+-- This fails - Users becomes users without quotes
+SELECT firstName FROM Users;
+-- ERROR: relation "users" does not exist
+```
+
+**Correct (lowercase snake_case):**
+
+```sql
+-- Unquoted lowercase identifiers are portable and tool-friendly
+CREATE TABLE users (
+  user_id bigint PRIMARY KEY,
+  first_name text,
+  last_name text
+);
+
+-- Works without quotes, recognized by all tools
+SELECT first_name FROM users WHERE user_id = 1;
+```
+
+Common sources of mixed-case identifiers:
+
+```sql
+-- ORMs often generate quoted camelCase - configure them to use snake_case
+-- Migrations from other databases may preserve original casing
+-- Some GUI tools quote identifiers by default - disable this
+
+-- If stuck with mixed-case, create views as a compatibility layer
+CREATE VIEW users AS SELECT "userId" AS user_id, "firstName" AS first_name FROM "Users";
+```
+
+Reference: [Identifiers and Key Words](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-partitioning.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-partitioning.md
@@ -1,0 +1,55 @@
+---
+title: Partition Large Tables for Better Performance
+impact: MEDIUM-HIGH
+impactDescription: 5-20x faster queries and maintenance on large tables
+tags: partitioning, large-tables, time-series, performance
+---
+
+## Partition Large Tables for Better Performance
+
+Partitioning splits a large table into smaller pieces, improving query performance and maintenance operations.
+
+**Incorrect (single large table):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz,
+  data jsonb
+);
+
+-- 500M rows, queries scan everything
+select * from events where created_at > '2024-01-01';  -- Slow
+vacuum events;  -- Takes hours, locks table
+```
+
+**Correct (partitioned by time range):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz not null,
+  data jsonb
+) partition by range (created_at);
+
+-- Create partitions for each month
+create table events_2024_01 partition of events
+  for values from ('2024-01-01') to ('2024-02-01');
+
+create table events_2024_02 partition of events
+  for values from ('2024-02-01') to ('2024-03-01');
+
+-- Queries only scan relevant partitions
+select * from events where created_at > '2024-01-15';  -- Only scans events_2024_01+
+
+-- Drop old data instantly
+drop table events_2023_01;  -- Instant vs DELETE taking hours
+```
+
+When to partition:
+
+- Tables > 100M rows
+- Time-series data with date-based queries
+- Need to efficiently drop old data
+
+Reference: [Table Partitioning](https://www.postgresql.org/docs/current/ddl-partitioning.html)

--- a/.agents/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
@@ -1,0 +1,61 @@
+---
+title: Select Optimal Primary Key Strategy
+impact: HIGH
+impactDescription: Better index locality, reduced fragmentation
+tags: primary-key, identity, uuid, serial, schema
+---
+
+## Select Optimal Primary Key Strategy
+
+Primary key choice affects insert performance, index size, and replication
+efficiency.
+
+**Incorrect (problematic PK choices):**
+
+```sql
+-- identity is the SQL-standard approach
+create table users (
+  id serial primary key  -- Works, but IDENTITY is recommended
+);
+
+-- Random UUIDs (v4) cause index fragmentation
+create table orders (
+  id uuid default gen_random_uuid() primary key  -- UUIDv4 = random = scattered inserts
+);
+```
+
+**Correct (optimal PK strategies):**
+
+```sql
+-- Use IDENTITY for sequential IDs (SQL-standard, best for most cases)
+create table users (
+  id bigint generated always as identity primary key
+);
+
+-- For distributed systems needing UUIDs, use UUIDv7 (time-ordered)
+-- Requires pg_uuidv7 extension: create extension pg_uuidv7;
+create table orders (
+  id uuid default uuid_generate_v7() primary key  -- Time-ordered, no fragmentation
+);
+
+-- Alternative: time-prefixed IDs for sortable, distributed IDs (no extension needed)
+create table events (
+  id text default concat(
+    to_char(now() at time zone 'utc', 'YYYYMMDDHH24MISSMS'),
+    gen_random_uuid()::text
+  ) primary key
+);
+```
+
+Guidelines:
+
+- Single database: `bigint identity` (sequential, 8 bytes, SQL-standard)
+- Distributed/exposed IDs: UUIDv7 (requires pg_uuidv7) or ULID (time-ordered, no
+  fragmentation)
+- `serial` works but `identity` is SQL-standard and preferred for new
+  applications
+- Avoid random UUIDs (v4) as primary keys on large tables (causes index
+  fragmentation)
+
+Reference:
+[Identity Columns](https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-PARMS-GENERATED-IDENTITY)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-privileges.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-privileges.md
@@ -1,0 +1,54 @@
+---
+title: Apply Principle of Least Privilege
+impact: MEDIUM
+impactDescription: Reduced attack surface, better audit trail
+tags: privileges, security, roles, permissions
+---
+
+## Apply Principle of Least Privilege
+
+Grant only the minimum permissions required. Never use superuser for application queries.
+
+**Incorrect (overly broad permissions):**
+
+```sql
+-- Application uses superuser connection
+-- Or grants ALL to application role
+grant all privileges on all tables in schema public to app_user;
+grant all privileges on all sequences in schema public to app_user;
+
+-- Any SQL injection becomes catastrophic
+-- drop table users; cascades to everything
+```
+
+**Correct (minimal, specific grants):**
+
+```sql
+-- Create role with no default privileges
+create role app_readonly nologin;
+
+-- Grant only SELECT on specific tables
+grant usage on schema public to app_readonly;
+grant select on public.products, public.categories to app_readonly;
+
+-- Create role for writes with limited scope
+create role app_writer nologin;
+grant usage on schema public to app_writer;
+grant select, insert, update on public.orders to app_writer;
+grant usage on sequence orders_id_seq to app_writer;
+-- No DELETE permission
+
+-- Login role inherits from these
+create role app_user login password 'xxx';
+grant app_writer to app_user;
+```
+
+Revoke public defaults:
+
+```sql
+-- Revoke default public access
+revoke all on schema public from public;
+revoke all on all tables in schema public from public;
+```
+
+Reference: [Roles and Privileges](https://supabase.com/blog/postgres-roles-and-privileges)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-basics.md
@@ -1,0 +1,50 @@
+---
+title: Enable Row Level Security for Multi-Tenant Data
+impact: CRITICAL
+impactDescription: Database-enforced tenant isolation, prevent data leaks
+tags: rls, row-level-security, multi-tenant, security
+---
+
+## Enable Row Level Security for Multi-Tenant Data
+
+Row Level Security (RLS) enforces data access at the database level, ensuring users only see their own data.
+
+**Incorrect (application-level filtering only):**
+
+```sql
+-- Relying only on application to filter
+select * from orders where user_id = $current_user_id;
+
+-- Bug or bypass means all data is exposed!
+select * from orders;  -- Returns ALL orders
+```
+
+**Correct (database-enforced RLS):**
+
+```sql
+-- Enable RLS on the table
+alter table orders enable row level security;
+
+-- Create policy for users to see only their orders
+create policy orders_user_policy on orders
+  for all
+  using (user_id = current_setting('app.current_user_id')::bigint);
+
+-- Force RLS even for table owners
+alter table orders force row level security;
+
+-- Set user context and query
+set app.current_user_id = '123';
+select * from orders;  -- Only returns orders for user 123
+```
+
+Policy for authenticated role:
+
+```sql
+create policy orders_user_policy on orders
+  for all
+  to authenticated
+  using (user_id = auth.uid());
+```
+
+Reference: [Row Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security)

--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -1,0 +1,63 @@
+---
+title: Optimize RLS Policies for Performance
+impact: HIGH
+impactDescription: 5-10x faster RLS queries with proper patterns
+tags: rls, performance, security, optimization
+---
+
+## Optimize RLS Policies for Performance
+
+Poorly written RLS policies can cause severe performance issues. Use subqueries and indexes strategically.
+
+**Incorrect (function called for every row):**
+
+```sql
+create policy orders_policy on orders
+  using (auth.uid() = user_id);  -- auth.uid() called per row!
+
+-- With 1M rows, auth.uid() is called 1M times
+```
+
+**Correct (wrap functions in SELECT):**
+
+```sql
+create policy orders_policy on orders
+  using ((select auth.uid()) = user_id);  -- Called once, cached
+
+-- 100x+ faster on large tables
+```
+
+Use security definer functions for complex checks:
+
+`SECURITY DEFINER` functions run with the creator's privileges and bypass RLS on any tables they touch — which is what makes them useful for internal lookups, but also what makes them dangerous if misused. Always include an explicit `auth.uid()` check inside the function body, keep them in a non-exposed schema, and revoke `EXECUTE` from any role that shouldn't call them directly.
+
+```sql
+-- Create helper function in a private schema
+create or replace function private.is_team_member(team_id bigint)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1 from public.team_members
+    -- always check the calling user's identity inside the function
+    where team_id = $1 and user_id = (select auth.uid())
+  );
+$$;
+
+-- Revoke direct execution from public roles
+revoke execute on function private.is_team_member(bigint) from PUBLIC, anon, authenticated, service_role;
+
+-- Use in policy (indexed lookup, not per-row check)
+create policy team_orders_policy on orders
+  using ((select private.is_team_member(team_id)));
+```
+
+Always add indexes on columns used in RLS policies:
+
+```sql
+create index orders_user_id_idx on orders (user_id);
+```
+
+Reference: [RLS Performance](https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations)

--- a/.agents/skills/supabase/CHANGELOG.md
+++ b/.agents/skills/supabase/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## [0.1.4](https://github.com/supabase/agent-skills/compare/v0.1.3...v0.1.4) (2026-06-05)
+
+
+### Features
+
+* add instructions to check changelog ([#74](https://github.com/supabase/agent-skills/issues/74)) ([4bb13d8](https://github.com/supabase/agent-skills/commit/4bb13d858d19f1f848505a66f46fc9603fdcde95))
+* add npm supply-chain security guidance to supabase skill ([#94](https://github.com/supabase/agent-skills/issues/94)) ([82df90a](https://github.com/supabase/agent-skills/commit/82df90a5de1cd84386d8bc192746e50343b86dc0))
+* instructions on exposing tables to the data api ([#71](https://github.com/supabase/agent-skills/issues/71)) ([f15a5a4](https://github.com/supabase/agent-skills/commit/f15a5a40779072a530c9e53c3f14ec4131118ea6))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* bump supabase skill to v0.1.1 and fix Data API broken link ([#72](https://github.com/supabase/agent-skills/issues/72)) ([5a6542e](https://github.com/supabase/agent-skills/commit/5a6542e08fc026d90c9a6a0f5a67749e9ceb9946))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))
+* update Data API doc link and bump supabase skill to v0.1.1 ([#73](https://github.com/supabase/agent-skills/issues/73)) ([e5f7a7c](https://github.com/supabase/agent-skills/commit/e5f7a7cfd697765848ffd6a4505f3c02e1ee17ee))
+
+## [0.1.3](https://github.com/supabase/agent-skills/compare/v0.1.2...v0.1.3) (2026-06-02)
+
+
+### Features
+
+* add instructions to check changelog ([#74](https://github.com/supabase/agent-skills/issues/74)) ([4bb13d8](https://github.com/supabase/agent-skills/commit/4bb13d858d19f1f848505a66f46fc9603fdcde95))
+* add npm supply-chain security guidance to supabase skill ([#94](https://github.com/supabase/agent-skills/issues/94)) ([82df90a](https://github.com/supabase/agent-skills/commit/82df90a5de1cd84386d8bc192746e50343b86dc0))
+* instructions on exposing tables to the data api ([#71](https://github.com/supabase/agent-skills/issues/71)) ([f15a5a4](https://github.com/supabase/agent-skills/commit/f15a5a40779072a530c9e53c3f14ec4131118ea6))
+* using Supabase agent skills ([#12](https://github.com/supabase/agent-skills/issues/12)) ([7c2e389](https://github.com/supabase/agent-skills/commit/7c2e3894fddfde8eb6c77d2a8921904543b9be7a))
+
+
+### Bug Fixes
+
+* bump supabase skill to v0.1.1 and fix Data API broken link ([#72](https://github.com/supabase/agent-skills/issues/72)) ([5a6542e](https://github.com/supabase/agent-skills/commit/5a6542e08fc026d90c9a6a0f5a67749e9ceb9946))
+* cover SECURITY DEFINER, auth.role() deprecation, and BOLA in security checklist ([#85](https://github.com/supabase/agent-skills/issues/85)) ([133f43e](https://github.com/supabase/agent-skills/commit/133f43e8c2ffc48823ff0630c692cabecea3e3a3))
+* update Data API doc link and bump supabase skill to v0.1.1 ([#73](https://github.com/supabase/agent-skills/issues/73)) ([e5f7a7c](https://github.com/supabase/agent-skills/commit/e5f7a7cfd697765848ffd6a4505f3c02e1ee17ee))

--- a/.agents/skills/supabase/SKILL.md
+++ b/.agents/skills/supabase/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: supabase
+description: "Use when doing ANY task involving Supabase. Triggers: Supabase products (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); client libraries and SSR integrations (supabase-js, @supabase/ssr) in Next.js, React, SvelteKit, Astro, Remix; auth issues (login, logout, sessions, JWT, cookies, getSession, getUser, getClaims, RLS); Supabase CLI or MCP server; schema changes, migrations, security audits, Postgres extensions (pg_graphql, pg_cron, pg_vector)."
+metadata:
+  author: supabase
+  version: "0.1.2"
+---
+
+# Supabase
+
+## Core Principles
+
+**1. Supabase changes frequently — verify against changelog and current docs before implementing.**
+Do not rely on training data for Supabase features. Function signatures, config.toml settings, and API conventions change between versions.
+
+First, fetch `https://supabase.com/changelog.md` (a lightweight summary index — not a heavy pull), scan for `breaking-change` tags relevant to your task, and follow the linked page for any that apply. Then look up the relevant topic using the documentation access methods below.
+
+**2. Verify your work.**
+After implementing any fix, run a test query to confirm the change works. A fix without verification is incomplete.
+
+**3. Recover from errors, don't loop.**
+If an approach fails after 2-3 attempts, stop and reconsider. Try a different method, check documentation, inspect the error more carefully, and review relevant logs when available. Supabase issues are not always solved by retrying the same command, and the answer is not always in the logs, but logs are often worth checking before proceeding.
+
+**4. Exposing tables to the Data API:** Depending on the user's [Data API settings](https://supabase.com/dashboard/project/<ref>/integrations/data_api/settings), newly created tables may not be automatically exposed via the Data (REST) API. If this is the case, `anon` and `authenticated` roles will need to be explicitly granted access.
+
+> Note that this is separate from RLS, which controls which _rows_ are visible once a table is accessible, not whether the table is accessible at all.
+
+When a user reports a SQL-created table is unexpectedly inaccessible, check their Data API settings and whether the roles have been granted access via explicit `GRANT` SQL. When granting public (`anon`/`authenticated`) access, always enable RLS too. See [Exposing a Table to the Data API](https://supabase.com/docs/guides/api/securing-your-api.md) for the full setup workflow.
+
+**5. RLS in exposed schemas.**
+Enable RLS on every table in any exposed schema, which includes `public` by default. This is critical in Supabase because tables in exposed schemas can be reachable through the Data API when the `anon`/`authenticated` roles have access (see [Exposing a Table to the Data API](https://supabase.com/docs/guides/api/securing-your-api.md)). For private schemas, prefer RLS as defense in depth. After enabling RLS, create policies that match the actual access model rather than defaulting every table to the same `auth.uid()` pattern.
+
+**6. Security checklist.**
+When working on any Supabase task that touches auth, RLS, views, storage, or user data, run through this checklist. These are Supabase-specific security traps that silently create vulnerabilities:
+
+- **Auth and session security**
+  - **Never use `user_metadata` claims in JWT-based authorization decisions.** In Supabase, `raw_user_meta_data` is user-editable and can appear in `auth.jwt()`, so it is unsafe for RLS policies or any other authorization logic. Store authorization data in `raw_app_meta_data` / `app_metadata` instead.
+  - **Deleting a user does not invalidate existing access tokens.** Sign out or revoke sessions first, keep JWT expiry short for sensitive apps, and for strict guarantees validate `session_id` against `auth.sessions` on sensitive operations.
+  - **If you use `app_metadata` or `auth.jwt()` for authorization, remember JWT claims are not always fresh until the user's token is refreshed.**
+
+- **API key and client exposure**
+  - **Never expose the `service_role` or secret key in public clients.** Prefer publishable keys for frontend code. Legacy `anon` keys are only for compatibility. In Next.js, any `NEXT_PUBLIC_` env var is sent to the browser.
+
+- **RLS, views, and privileged database code**
+  - **Views bypass RLS by default.** In Postgres 15 and above, use `CREATE VIEW ... WITH (security_invoker = true)`. In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
+  - **UPDATE requires a SELECT policy.** In Postgres RLS, an UPDATE needs to first SELECT the row. Without a SELECT policy, updates silently return 0 rows — no error, just no change.
+  - **`auth.role()` is deprecated — use the `TO` clause instead.** Supabase has deprecated `auth.role()` in favour of specifying the target role directly on the policy with `TO authenticated` or `TO anon`. Beyond deprecation, `auth.role() = 'authenticated'` breaks silently when anonymous sign-ins are enabled, because anonymous users carry the `authenticated` Postgres role and pass the check regardless of whether the user is genuinely signed in.
+    ```sql
+    -- Deprecated (do not use)
+    create policy "example" on table_name for select
+    using ( auth.role() = 'authenticated' );
+    ```
+  - **`TO authenticated` alone is authentication without authorization (BOLA / IDOR).** Using `TO authenticated` only checks the role — it does not restrict which rows a user can access. The correct pattern combines `TO authenticated` with an ownership predicate in `USING`:
+    ```sql
+    create policy "example" on table_name for select
+    to authenticated
+    using ( (select auth.uid()) = user_id );
+    ```
+  - **UPDATE policies require both `USING` and `WITH CHECK`.** Without `WITH CHECK`, a user can reassign a row's `user_id` to another user:
+    ```sql
+    create policy "example" on table_name for update
+    to authenticated
+    using ( (select auth.uid()) = user_id )
+    with check ( (select auth.uid()) = user_id );
+    ```
+  - **`SECURITY DEFINER` functions bypass RLS.** A `SECURITY DEFINER` function runs with its creator's privileges — typically a role with `bypassrls` (e.g., `postgres`). Never add `SECURITY DEFINER` to resolve a permission error; it silently removes access control without fixing the underlying cause. Prefer `SECURITY INVOKER`.
+  - **`SECURITY DEFINER` functions in `public` are callable by all roles.** Postgres grants `EXECUTE` to `PUBLIC` by default for every new function, so any `SECURITY DEFINER` function in `public` is a public API endpoint callable by `anon` and `authenticated` (which inherit from `PUBLIC`) without any additional grant. When `SECURITY DEFINER` is genuinely needed (e.g., bypassing RLS on an internal lookup table), keep the function in a non-exposed schema, always include an `auth.uid()` check in the function body, and run `supabase db advisors` after making changes.
+
+- **Storage access control**
+  - **Storage upsert requires INSERT + SELECT + UPDATE.** Granting only INSERT allows new uploads but file replacement (upsert) silently fails. You need all three.
+
+- **Dependency and supply-chain security**
+  - **Always pin package versions and commit lockfiles** when installing Supabase packages (`supabase-js`, `@supabase/ssr`, `supabase-py`, etc.). See the [npm security guide](https://supabase.com/docs/guides/security/npm-security.md) for the full checklist.
+
+For any security concern not covered above, fetch the Supabase product security index: `https://supabase.com/docs/guides/security/product-security.md`
+
+## Supabase CLI
+
+Always discover commands via `--help` — never guess. The CLI structure changes between versions.
+
+```bash
+supabase --help                    # All top-level commands
+supabase <group> --help            # Subcommands (e.g., supabase db --help)
+supabase <group> <command> --help  # Flags for a specific command
+```
+
+**Supabase CLI Known gotchas:**
+
+- `supabase db query` requires **CLI v2.79.0+** → use MCP `execute_sql` or `psql` as fallback
+- `supabase db advisors` requires **CLI v2.81.3+** → use MCP `get_advisors` as fallback
+- When you need a new migration SQL file, **always** create it with `supabase migration new <name>` first. Never invent a migration filename or rely on memory for the expected format.
+
+**Version check and upgrade:** Run `supabase --version` to check. For CLI changelogs and version-specific features, consult the [CLI documentation](https://supabase.com/docs/reference/cli/introduction) or [GitHub releases](https://github.com/supabase/cli/releases).
+
+## Supabase MCP Server
+
+For setup instructions, server URL, and configuration, see the [MCP setup guide](https://supabase.com/docs/guides/getting-started/mcp).
+
+**Troubleshooting connection issues** — follow these steps in order:
+
+1. **Check if the server is reachable:**
+   `curl -so /dev/null -w "%{http_code}" https://mcp.supabase.com/mcp`
+   A `401` is expected (no token) and means the server is up. Timeout or "connection refused" means it may be down.
+
+2. **Check `.mcp.json` configuration:**
+   Verify the project root has a valid `.mcp.json` with the correct server URL. If missing, create one pointing to `https://mcp.supabase.com/mcp`.
+
+3. **Authenticate the MCP server:**
+   If the server is reachable and `.mcp.json` is correct but tools aren't visible, the user needs to authenticate. The Supabase MCP server uses OAuth 2.1 — tell the user to trigger the auth flow in their agent, complete it in the browser, and reload the session.
+
+## Supabase Documentation
+
+Before implementing any Supabase feature, find the relevant documentation. Use these methods in priority order:
+
+1. **MCP `search_docs` tool** (preferred — returns relevant snippets directly)
+2. **Fetch docs pages as markdown** — any docs page can be fetched by appending `.md` to the URL path.
+3. **Web search** for Supabase-specific topics when you don't know which page to look at.
+
+## Making and Committing Schema Changes
+
+**To make schema changes, use `execute_sql` (MCP) or `supabase db query` (CLI).** These run SQL directly on the database without creating migration history entries, so you can iterate freely and generate a clean migration when ready.
+
+Do NOT use `apply_migration` to change a local database schema — it writes a migration history entry on every call, which means you can't iterate, and `supabase db diff` / `supabase db pull` will produce empty or conflicting diffs. If you use it, you'll be stuck with whatever SQL you passed on the first try.
+
+**When ready to commit** your changes to a migration file:
+
+1. **Run advisors** → `supabase db advisors` (CLI v2.81.3+) or MCP `get_advisors`. Fix any issues.
+2. **Review the Security Checklist above** if your changes involve views, functions, triggers, or storage.
+3. **Generate the migration** → `supabase db pull <descriptive-name> --local --yes`
+4. **Verify** → `supabase migration list --local`
+
+## Reference Guides
+
+- **Skill Feedback** → [references/skill-feedback.md](references/skill-feedback.md)
+  **MUST read when** the user reports that this skill gave incorrect guidance or is missing information.

--- a/.agents/skills/supabase/assets/feedback-issue-template.md
+++ b/.agents/skills/supabase/assets/feedback-issue-template.md
@@ -1,0 +1,17 @@
+## What happened
+
+**Task:** <!-- e.g., "Set up MFA on patient records" -->
+
+**Skill said:** <!-- e.g., "Use auth.jwt()->'app_metadata' in the RLS policy" -->
+
+**Expected:** <!-- e.g., "The function also needs SECURITY DEFINER + grant to supabase_auth_admin" -->
+
+## Source
+
+**File:** <!-- e.g., references/security-model.md -->
+
+**Section:** <!-- e.g., "Trust Boundaries > user_metadata vs app_metadata" -->
+
+## Fix suggestion
+
+<!-- Leave blank if unsure -->

--- a/.agents/skills/supabase/references/skill-feedback.md
+++ b/.agents/skills/supabase/references/skill-feedback.md
@@ -1,0 +1,17 @@
+# Skill Feedback
+
+Use this when the user reports that the skill gave incorrect guidance, is missing information, or could be improved. This is about the skill (agent instructions), not about Supabase the product.
+
+## Steps
+
+1. **Ask permission** — Ask the user if they'd like to submit feedback to the skill maintainers. If they decline, move on.
+
+2. **Draft the issue** — Use the template at [assets/feedback-issue-template.md](../assets/feedback-issue-template.md) to structure the feedback. Fill in the fields based on the conversation. Always identify which specific reference file and section caused the problem.
+
+3. **Submit** — Create a GitHub Issue on the `supabase/agent-skills` repository using the draft as the issue body. The title must follow this format: `user-feedback: <summary of the problem>`.
+
+4. **Share the result** — Share the issue URL with the user after submission. If submission fails, give the user this link to create the issue manually:
+
+```
+https://github.com/supabase/agent-skills/issues/new
+```

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,72 @@
+name: Deploy Saleor to Azure Container Apps (Production)
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_image_tag:
+        description: "Image tag for ghcr.io/saleor/saleor"
+        required: false
+        default: "3.23"
+      dashboard_image_tag:
+        description: "Image tag for ghcr.io/saleor/saleor-dashboard"
+        required: false
+        default: "3.23"
+      run_migrations:
+        description: "Run the saleor-migrate job after updating the API image"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  RESOURCE_GROUP: rg-rover-saleor-prod
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Update saleor-api image
+        run: |
+          az containerapp update \
+            --name saleor-api \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --image ghcr.io/saleor/saleor:${{ inputs.api_image_tag }}
+
+      - name: Update saleor-worker image
+        run: |
+          az containerapp update \
+            --name saleor-worker \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --image ghcr.io/saleor/saleor:${{ inputs.api_image_tag }}
+
+      - name: Update saleor-beat image
+        run: |
+          az containerapp update \
+            --name saleor-beat \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --image ghcr.io/saleor/saleor:${{ inputs.api_image_tag }}
+
+      - name: Update saleor-dashboard image
+        run: |
+          az containerapp update \
+            --name saleor-dashboard \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --image ghcr.io/saleor/saleor-dashboard:${{ inputs.dashboard_image_tag }}
+
+      - name: Run database migrations
+        if: ${{ inputs.run_migrations == true || inputs.run_migrations == 'true' }}
+        run: |
+          az containerapp job start \
+            --name saleor-migrate \
+            --resource-group ${{ env.RESOURCE_GROUP }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -70,3 +70,11 @@ jobs:
           az containerapp job start \
             --name saleor-migrate \
             --resource-group ${{ env.RESOURCE_GROUP }}
+
+      - name: Notify storefront to regenerate GraphQL types
+        env:
+          GH_TOKEN: ${{ secrets.STOREFRONT_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/danprivera/rovershop-storefront/dispatches \
+            -f event_type=saleor-deployed \
+            -f "client_payload[api_image_tag]=${{ inputs.api_image_tag }}"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -173,6 +173,11 @@ az containerapp job start --name saleor-migrate --resource-group rg-rover-saleor
 az containerapp job start --name saleor-createsuperuser --resource-group rg-rover-saleor-prod
 ```
 
+Already created and verified working (`admin@rovershop.io`, credentials in Key Vault
+`saleor-admin-email`/`saleor-admin-password`). To verify login without opening the dashboard,
+send a `tokenCreate` mutation to `/graphql/` — an empty `errors` array with a `token` confirms
+the account works.
+
 ### Deploy a new image version
 
 Use the "Deploy Saleor to Azure Container Apps (Production)" GitHub Actions workflow
@@ -193,6 +198,34 @@ Requires a CNAME (and TXT `asuid.<hostname>` for validation) added at GoDaddy po
 container app's default FQDN before binding. Repeat for `saleor-dashboard` / `admin.rovershop.io`.
 Managed certificate issuance can take up to 20 minutes after binding (in practice both were
 `Succeeded` almost immediately for this deployment).
+
+## Troubleshooting notes
+
+- **Reading logs for a specific revision/replica**: `az containerapp logs show --type system` does
+  not support `--container`/`--replica`/`--revision` filters — omit `--type system` (default console
+  logs) when scoping to a revision.
+- **Testing before a custom domain is bound**: Container Apps ingress routes by `Host` header at the
+  environment level, so overriding `Host` via curl against the default FQDN for an unbound hostname
+  just returns a generic environment 404, not the app's response. To smoke-test the API before DNS/
+  domain binding is complete, allow-list the app's own default FQDN in `ALLOWED_HOSTS` instead.
+- **Azure Portal can show stale/cached resource lists** (e.g. showed 4 Postgres servers after
+  earlier ones were deleted, when only one actually existed). Always cross-check with
+  `az postgres flexible-server list` / `az resource list` before assuming a portal-displayed
+  resource is real.
+- **`ScaledObject doesn't have correct triggers specification` warning** on `saleor-worker`/
+  `saleor-beat` is cosmetic — both are pinned at `minReplicas == maxReplicas == 1`, so no scale
+  rules are needed.
+- **PowerShell + curl JSON bodies**: inline `curl.exe -d '{"query":"..."}'` from PowerShell mangles
+  quoting, and `Out-File -Encoding utf8` can add a BOM that breaks JSON parsing. Reliable approach:
+  `[System.IO.File]::WriteAllText($path, $jsonString)` then `curl.exe --data-binary "@$path"`.
+- **Generating an RSA key without `openssl`** (not available in this Windows PowerShell
+  environment): use Python's `cryptography` library (`rsa.generate_private_key` +
+  `private_bytes(..., format=TraditionalOpenSSL, encryption_algorithm=NoEncryption())`), write to a
+  temp file, upload with `az keyvault secret set --file`, then delete the local plaintext file.
+- **A long-running `az deployment group create` can appear to fail client-side** ("Long-running
+  operation wait cancelled") if another terminal command runs concurrently in the same session —
+  the actual Azure-side deployment is unaffected; confirm with
+  `az deployment group show --query properties.provisioningState`.
 
 ## Roadmap
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,209 @@
+# Saleor Production Deployment (Azure Container Apps)
+
+This document describes the production deployment of Saleor for Rover Shop, separate from the
+local development setup described in the main [README.md](./README.md) (which remains
+docker-compose based and is for local development only).
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph Internet
+        Customer
+        Staff
+    end
+
+    Customer -->|HTTPS| API[saleor-api]
+    Staff -->|HTTPS| Dashboard[saleor-dashboard]
+    Dashboard -->|GraphQL over HTTPS| API
+
+    subgraph "Container Apps Environment: rover-ai-env (rg-rover-saleor-prod)"
+        API
+        Dashboard
+        Worker[saleor-worker]
+        Beat[saleor-beat]
+        Valkey[(valkey - internal only)]
+    end
+
+    API --> Valkey
+    Worker --> Valkey
+    Beat --> Valkey
+
+    API --> Postgres[(Azure Postgres Flexible Server)]
+    Worker --> Postgres
+    Beat --> Postgres
+
+    API --> Blob[(Azure Blob Storage - media)]
+    API --> SendGrid[SendGrid SMTP]
+
+    KV[(Key Vault: rover-technologies-vault)] -.secrets.-> API
+    KV -.secrets.-> Worker
+    KV -.secrets.-> Beat
+```
+
+- **saleor-api** — Saleor GraphQL API (`ghcr.io/saleor/saleor`), external ingress, custom domain `api.rovershop.io`
+- **saleor-dashboard** — Saleor Dashboard (`ghcr.io/saleor/saleor-dashboard`), external ingress, custom domain `admin.rovershop.io`
+- **saleor-worker** — Celery worker (no `-B`), no ingress
+- **saleor-beat** — Celery beat scheduler, fixed at exactly 1 replica (no ingress). Kept separate from
+  the worker so that scaling the worker never causes scheduled tasks to fire more than once.
+- **valkey** — Redis-compatible cache/broker, internal-only ingress, single replica
+- **saleor-migrate** / **saleor-createsuperuser** — Container Apps Jobs (manual trigger) used for
+  one-off database operations, since Saleor does not auto-migrate on container start
+
+Postgres is an Azure Database for PostgreSQL Flexible Server (Burstable `Standard_B2s`), not a
+container. It's reachable over the public endpoint with a firewall rule allowing Azure-internal
+traffic (Container Apps Environment doesn't have a fixed outbound IP without a NAT gateway/VNet
+integration). Media uploads go to Azure Blob Storage via Saleor's native `AzureMediaStorage` backend
+(no custom image needed). Email is sent via SendGrid SMTP. Jaeger and Mailpit from the local
+docker-compose stack are dev-only and are not part of this deployment.
+
+> **Postgres extensions**: Azure Postgres Flexible Server requires extensions to be explicitly
+> allow-listed before Django migrations can `CREATE EXTENSION`. This is configured via the
+> `azure.extensions` server parameter (dynamic, no restart required):
+> ```powershell
+> az postgres flexible-server parameter set --resource-group rg-rover-saleor-prod `
+>   --server-name psql-rover-saleor-prod-04 --name azure.extensions `
+>   --value "hstore,pg_trgm,unaccent,btree_gin,btree_gist,citext,pgcrypto,uuid-ossp"
+> ```
+
+> **`DEBUG=False` in production**: Saleor enforces two additional required settings whenever
+> `DEBUG=False`, both of which will crash the container at startup (`ImproperlyConfigured`) if
+> missing: `ALLOWED_CLIENT_HOSTS` (used by Saleor's outbound HTTP client SSRF/IP-filter
+> protection) and `RSA_PRIVATE_KEY` (used for JWT signing; without a fixed key, tokens wouldn't
+> survive a restart or be valid across multiple replicas). Both are set in `containerApps.bicep`.
+
+> Supabase was evaluated first but abandoned: Supabase's direct DB host is IPv6-only (no A record),
+> and Azure Container Apps has no IPv6 egress, so it could not be reached at all without extra
+> networking. Azure Postgres Flexible Server avoids this entirely since it's native to Azure.
+
+## Resource inventory
+
+| Resource | Name | Notes |
+|---|---|---|
+| Resource group | `rg-rover-saleor-prod` | East US 2 |
+| Container Apps environment | `rover-ai-env` | |
+| Log Analytics workspace | `log-rover-saleor-prod` | Container Apps logs |
+| Storage account | `strovershopmediaprod` | `media` blob container, public blob read |
+| Postgres Flexible Server | `psql-rover-saleor-prod-04` | Burstable `Standard_B2s`, PostgreSQL 15, database `saleor` |
+| Managed identity | `id-rover-saleor-prod` | Used by api/worker/beat/jobs to read Key Vault secrets |
+| Key Vault | `rover-technologies-vault` (existing, `rover-technologies-rg`) | Shared vault; Saleor secrets are prefixed `saleor-` |
+| Container Apps | `saleor-api`, `saleor-worker`, `saleor-beat`, `saleor-dashboard`, `valkey` | |
+| Container Apps Jobs | `saleor-migrate`, `saleor-createsuperuser` | Manual trigger only |
+
+## Key Vault secrets
+
+All Saleor secrets are prefixed `saleor-` to distinguish them from other projects sharing this vault
+(Strapi, RoverChat, RoverFlow, etc.):
+
+| Secret name | Purpose | Source |
+|---|---|---|
+| `saleor-database-url` | Azure Postgres connection string (`sslmode=require`) | Written directly by Bicep (`modules/keyVaultSecret.bicep`) from the generated admin password; never typed in manually |
+| `saleor-secret-key` | Django `SECRET_KEY` | Generated |
+| `rovershop-sendgrid-connection-string` | SendGrid SMTP URL for `EMAIL_URL` | SendGrid API key |
+| `saleor-storage-account-key` | Azure Storage account key for media | Azure |
+| `saleor-admin-email` | Bootstrap superuser email | Generated (`admin@rovershop.io`, change as needed) |
+| `saleor-admin-password` | Bootstrap superuser password | Generated |
+| `saleor-rsa-private-key` | RSA private key for JWT signing (`RSA_PRIVATE_KEY`); required whenever `DEBUG=False` | Generated (2048-bit, PEM, no passphrase) |
+
+> Note: the SendGrid secret uses the `rovershop-` prefix instead of `saleor-` because it was added
+> directly to the shared vault by the account owner under that existing naming convention.
+> `saleor-database-url` is composed and written entirely by the `main.bicep` deployment (the
+> Postgres admin password is passed as a secure deployment parameter, generated fresh each
+> deployment run and never committed to a file or shown in chat).
+
+## Environment variable mapping (compose -> production)
+
+| docker-compose (backend.env/common.env) | Production value |
+|---|---|
+| `DATABASE_URL` | Azure Postgres connection string (Key Vault, written by Bicep) |
+| `CACHE_URL` | `redis://valkey:6379/0` (internal Container Apps DNS) |
+| `CELERY_BROKER_URL` | `redis://valkey:6379/1` |
+| `EMAIL_URL` | SendGrid SMTP URL (Key Vault) |
+| `SECRET_KEY` | Generated, stored in Key Vault |
+| n/a | `DEBUG=False` (required for production; see note below) |
+| n/a | `RSA_PRIVATE_KEY` (Key Vault `saleor-rsa-private-key`; required when `DEBUG=False`) |
+| n/a | `ALLOWED_CLIENT_HOSTS` (required when `DEBUG=False`; set to same value as `ALLOWED_HOSTS`) |
+| `ALLOWED_HOSTS` | `api.rovershop.io,saleor-api.<env-default-domain>` (the container app's own default FQDN is also allow-listed so the API can be smoke-tested directly, independent of custom domain/DNS status) |
+| n/a | `PUBLIC_URL=https://api.rovershop.io` |
+| `DASHBOARD_URL` | `https://admin.rovershop.io` |
+| n/a | `AZURE_CONTAINER=media`, `AZURE_ACCOUNT_NAME`, `AZURE_ACCOUNT_KEY` (media storage) |
+| `OTEL_*` | Removed (observability skipped for initial launch) |
+
+## Domain strategy
+
+- `api.rovershop.io` / `admin.rovershop.io` — this deployment (cheap TLD, not customer-typed)
+- `rovershop.ai` — reserved exclusively for future customer-facing, multi-tenant storefronts
+- DNS is hosted at GoDaddy; Azure Container Apps Managed Certificates (free, auto-renewing,
+  per-hostname) are used for the two hostnames above
+- **Status: live.** Both hostnames are bound with `SniEnabled` and issued managed certificates
+  (`mc-rover-ai-env-api-rovershop-io-3338`, `mc-rover-ai-env-admin-rovershop--9895`). Verified
+  reachable over HTTPS with a working GraphQL query and dashboard load.
+
+## Runbook
+
+### Initial deploy (already performed for infra + CI/CD scaffolding)
+
+```powershell
+az group create --name rg-rover-saleor-prod --location eastus2
+az deployment group create `
+  --resource-group rg-rover-saleor-prod `
+  --template-file infra/main.bicep `
+  --parameters infra/main.parameters.prod.json
+```
+
+### Add/rotate a secret
+
+Secrets are referenced directly from Key Vault by the container apps (via managed identity), so
+rotating a secret in Key Vault requires restarting the affected app's revision to pick up the new value:
+
+```powershell
+az keyvault secret set --vault-name rover-technologies-vault --name saleor-<name> --value "<value>"
+az containerapp revision restart --name saleor-api --resource-group rg-rover-saleor-prod
+```
+
+### Run database migrations
+
+```powershell
+az containerapp job start --name saleor-migrate --resource-group rg-rover-saleor-prod
+```
+
+### Create/reset the bootstrap superuser
+
+```powershell
+az containerapp job start --name saleor-createsuperuser --resource-group rg-rover-saleor-prod
+```
+
+### Deploy a new image version
+
+Use the "Deploy Saleor to Azure Container Apps (Production)" GitHub Actions workflow
+(`.github/workflows/deploy-production.yml`), triggered manually with the desired image tags, or:
+
+```powershell
+az containerapp update --name saleor-api --resource-group rg-rover-saleor-prod --image ghcr.io/saleor/saleor:<tag>
+```
+
+### Bind a custom domain + managed certificate (already performed for api/admin.rovershop.io)
+
+```powershell
+az containerapp hostname add --name saleor-api --resource-group rg-rover-saleor-prod --hostname api.rovershop.io
+az containerapp hostname bind --name saleor-api --resource-group rg-rover-saleor-prod --hostname api.rovershop.io --environment rover-ai-env --validation-method CNAME
+```
+
+Requires a CNAME (and TXT `asuid.<hostname>` for validation) added at GoDaddy pointing at the
+container app's default FQDN before binding. Repeat for `saleor-dashboard` / `admin.rovershop.io`.
+Managed certificate issuance can take up to 20 minutes after binding (in practice both were
+`Succeeded` almost immediately for this deployment).
+
+## Roadmap
+
+- **Staging environment**: not yet built. Plan is to reuse the same Bicep modules with a
+  `-stage` suffix (new resource group, e.g. `rg-rover-saleor-stage`, environment name, storage
+  account, and Supabase project), with subdomains `api-stage.rovershop.io` / `admin-stage.rovershop.io`.
+- **Multi-tenant vendor storefronts** under `rovershop.ai`: a separate, larger architecture
+  effort (Saleor Channels + subdomain routing, or per-tenant instances, or a custom marketplace
+  layer), plus a wildcard certificate or Azure Front Door in front of Container Apps once the
+  number of vendor subdomains grows beyond a handful.
+- **Observability**: currently skipped; revisit Azure Monitor/Application Insights via
+  OpenTelemetry when needed.
+- **roverpay.io** (payments) and **roverai.io/roverchat.ai** (AI assistant) integrations are
+  separate initiatives, out of scope for this deployment.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -21,6 +21,36 @@ record).
 | First Saleor app token | ✅ 2026-07-11 — app `rovershop-vendor-dashboard` (`QXBwOjE=`), MANAGE_PRODUCTS + MANAGE_ORDERS, token in Key Vault `rovershop-dashboard-saleor-app-token`; powers dashboard product CRUD (non-expiring, replaces admin-JWT pattern for the dashboard) |
 | Product media / blob storage | ✅ **Fixed 2026-07-11** — media upload had never worked: Saleor called `strovershopmediaprod` over plain HTTP → `AccountRequiresHttps`. `AZURE_SSL=True` set on `saleor-api` + `saleor-worker` (revisions `--0000005`). `productMediaCreate` verified working. |
 
+## Rover Pay (payments container, added 2026-07-12)
+
+Container app **`rover-pay`** (rg-rover-saleor-prod, `rover-ai-env`) runs the Saleor Stripe
+payment app — image `ghcr.io/djkato/saleor-app-payment-stripe:0.4.0` (community dockerization
+of saleor/saleor-app-payment-stripe; **listens on port 3000**, not the 3001 its compose example
+suggests). Env: `SECRET_KEY` (KV `rover-pay-app-secret-key`), `APL=redis`,
+`REDIS_URL=redis://valkey:6379/5`, `APP_API_BASE_URL`/`APP_IFRAME_BASE_URL`. Custom domain
+**pay.rovershop.io** (CNAME + `asuid.pay` TXT at the registrar) because Saleor's SSRF guard
+(`HTTP_IP_FILTER_ENABLED=True`) blocks same-environment FQDNs, which resolve to private IPs —
+app installs/webhooks require a publicly-resolving host. Manifest id `app.saleor.stripe`
+matches the storefront checkout's `stripeGatewayId`; when a channel has a mapped config the
+checkout's Stripe card UI automatically replaces the PayLater fallback.
+
+**Stripe sandbox config**: keys in KV — `rovershop-stripe-sandbox-secret-key` (sk_test, the
+app rejects restricted rk_ keys), `-publishable-key` (pk_test), `-api-key` (rk_test, unused by
+this app). Config entry "RoverShop sandbox" is mapped to every channel so all vendors test
+through the shared sandbox; per-vendor Stripe accounts come later. Configuration is scriptable:
+the app's tRPC (`/api/trpc/paymentConfig.add`, `mapping.update`) accepts a Saleor staff JWT via
+`authorization-bearer` + `saleor-api-url` headers (needs MANAGE_APPS + MANAGE_SETTINGS; the
+`Origin` header must be the app URL — it's used to build the auto-created Stripe webhook).
+
+**Rover Pay evolution plan**: this container is the seed of Rover Pay (roverpay.ai). Path:
+fork `saleor/saleor-app-payment-stripe` → `rover-pay` repo; keep the transaction-flow webhook
+surface (`PAYMENT_GATEWAY_INITIALIZE_SESSION`, `TRANSACTION_INITIALIZE/PROCESS/...`) and add
+processors behind per-vendor configuration entries (the app's config-entry + channel-mapping
+model already supports N configs → N channels — exactly the multi-vendor shape needed). The
+storefront gateway id can stay `app.saleor.stripe` until the fork renames it (renaming requires
+updating the checkout's `stripeGatewayId` + reinstall). Infra TODO: pin `rover-pay` in bicep
+(it was created imperatively) and bind api.roverpay.ai when the product brand goes live.
+
 ## Next steps
 
 1. **Wrap the provisioning-script pattern as MCP tools and/or a vendor-provisioning portal** so

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -18,6 +18,8 @@ record).
 | Per-channel `featured-products-{channel}` collections | ✅ Done |
 | Provisioning pattern | ✅ Proven twice, idempotent (`scripts/provision-*.mjs`) |
 | Automated provisioning (MCP tools / portal) | ⏳ Not started — explicit next phase |
+| First Saleor app token | ✅ 2026-07-11 — app `rovershop-vendor-dashboard` (`QXBwOjE=`), MANAGE_PRODUCTS + MANAGE_ORDERS, token in Key Vault `rovershop-dashboard-saleor-app-token`; powers dashboard product CRUD (non-expiring, replaces admin-JWT pattern for the dashboard) |
+| Product media / blob storage | ✅ **Fixed 2026-07-11** — media upload had never worked: Saleor called `strovershopmediaprod` over plain HTTP → `AccountRequiresHttps`. `AZURE_SSL=True` set on `saleor-api` + `saleor-worker` (revisions `--0000005`). `productMediaCreate` verified working. |
 
 ## Next steps
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,46 @@
+# rovershop-saleor-platform — Progress & Next Steps
+
+Companion to [PROJECT.md](./PROJECT.md) and [DEPLOYMENT.md](./DEPLOYMENT.md). Scope: this repo
+only; platform-wide status lives in
+[rovershop-saleor-storefront/PROGRESS.md](../rovershop-saleor-storefront/PROGRESS.md) (doc of
+record).
+
+> **Agents:** treat the Next Steps below as standing tasks — persist them (and anything you
+> learn working here) into your session memory so they survive context loss, and update this
+> file whenever you finish or reprioritize one.
+
+## Status (2026-07-11)
+
+| Area | Status |
+| --- | --- |
+| Production deployment (api.rovershop.io / admin.rovershop.io) | ✅ Live |
+| Vendor channels | ✅ `illnails` (11 real services as products), `deliajewelry` (6 placeholder products), `default-channel` placeholder catalog |
+| Per-channel `featured-products-{channel}` collections | ✅ Done |
+| Provisioning pattern | ✅ Proven twice, idempotent (`scripts/provision-*.mjs`) |
+| Automated provisioning (MCP tools / portal) | ⏳ Not started — explicit next phase |
+
+## Next steps
+
+1. **Wrap the provisioning-script pattern as MCP tools and/or a vendor-provisioning portal** so
+   onboarding a vendor doesn't require hand-running a bespoke Node script (explicitly called
+   out as the next phase; needs its own least-privilege credential pattern rather than a human
+   operator's full Key Vault pull — storefront PROGRESS §5.6).
+2. Replace Delia Jewelry's placeholder catalog with real inventory when available.
+3. Model the provisioning workflow as an idempotent, retryable state machine on
+   `vendor.vendorStatus` (rollback/dead-letter semantics — storefront PROGRESS §5.4).
+4. Decide the vendor-count threshold at which a single Saleor instance needs sharding
+   (storefront PROGRESS §5.5).
+5. Tax/compliance integration (Avalara/TaxJar or Saleor tax app) before Phase 2 nears
+   production (storefront PROGRESS §5.10).
+6. Automated secret rotation for the Saleor admin credentials in
+   `rover-technologies-vault`.
+
+## Cross-references
+
+- Platform doc of record + theming-system status:
+  [storefront PROGRESS.md](../rovershop-saleor-storefront/PROGRESS.md) (§1b documents both
+  vendor onboardings done from this repo; §1d the theming stack awaiting deploy)
+- Tenant config source of truth (`vendor.saleorChannel`):
+  [roverai-strapi-platform/PROGRESS.md](../roverai-strapi-platform/PROGRESS.md)
+- Dashboard that will eventually drive provisioning:
+  [rovershop-dashboard-web/PROGRESS.md](../rovershop-dashboard-web/PROGRESS.md)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -70,6 +70,16 @@ storefront gateway id can stay `app.saleor.stripe` until the fork renames it (re
 updating the checkout's `stripeGatewayId` + reinstall). Infra TODO: pin `rover-pay` in bicep
 (it was created imperatively) and bind api.roverpay.ai when the product brand goes live.
 
+## ⚠️ Provisioning gap found 2026-07-13: shipping-method channel listings
+
+A real payment got stuck ("Almost done…" hang; charged but uncompletable checkout) because the
+**Default shipping method had a channel listing (price) only for `default-channel`** — the
+vendor channels had zero available shipping methods, so shipping-required checkouts could
+never complete. Zone assignment (`addShippingZones` at channelCreate) is **not enough**:
+every new channel also needs `shippingMethodChannelListingUpdate` with
+`addChannels: [{ channelId, price }]` for each method it should offer. Fixed live for
+`deliajewelry`/`illnails` ($0 listings); **add this step to the provisioning scripts/portal.**
+
 ## Next steps
 
 1. **Wrap the provisioning-script pattern as MCP tools and/or a vendor-provisioning portal** so

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -21,26 +21,45 @@ record).
 | First Saleor app token | ✅ 2026-07-11 — app `rovershop-vendor-dashboard` (`QXBwOjE=`), MANAGE_PRODUCTS + MANAGE_ORDERS, token in Key Vault `rovershop-dashboard-saleor-app-token`; powers dashboard product CRUD (non-expiring, replaces admin-JWT pattern for the dashboard) |
 | Product media / blob storage | ✅ **Fixed 2026-07-11** — media upload had never worked: Saleor called `strovershopmediaprod` over plain HTTP → `AccountRequiresHttps`. `AZURE_SSL=True` set on `saleor-api` + `saleor-worker` (revisions `--0000005`). `productMediaCreate` verified working. |
 
-## Rover Pay (payments container, added 2026-07-12)
+## Rover Pay (payments service, added 2026-07-12, LIVE & E2E-verified 2026-07-13)
 
-Container app **`rover-pay`** (rg-rover-saleor-prod, `rover-ai-env`) runs the Saleor Stripe
-payment app — image `ghcr.io/djkato/saleor-app-payment-stripe:0.4.0` (community dockerization
-of saleor/saleor-app-payment-stripe; **listens on port 3000**, not the 3001 its compose example
-suggests). Env: `SECRET_KEY` (KV `rover-pay-app-secret-key`), `APL=redis`,
-`REDIS_URL=redis://valkey:6379/5`, `APP_API_BASE_URL`/`APP_IFRAME_BASE_URL`. Custom domain
-**pay.rovershop.io** (CNAME + `asuid.pay` TXT at the registrar) because Saleor's SSRF guard
-(`HTTP_IP_FILTER_ENABLED=True`) blocks same-environment FQDNs, which resolve to private IPs —
-app installs/webhooks require a publicly-resolving host. Manifest id `app.saleor.stripe`
-matches the storefront checkout's `stripeGatewayId`; when a channel has a mapped config the
-checkout's Stripe card UI automatically replaces the PayLater fallback.
+**Live at `https://api.roverpay.io`** — container app **`rover-pay`** in its **own environment
+`rover-pay-env` (rg-rover-pay-prod)** with a private `valkey` sidecar app (APL storage). Runs
+the Saleor Stripe payment app — image `ghcr.io/djkato/saleor-app-payment-stripe:0.4.0`
+(community dockerization of saleor/saleor-app-payment-stripe; **listens on port 3000**, not
+the 3001 its compose example suggests). Env: `SECRET_KEY` (KV `rover-pay-app-secret-key`),
+`APL=redis`, `REDIS_URL=redis://valkey:6379/0`, `APP_API_BASE_URL`/`APP_IFRAME_BASE_URL`
+(**required** — RedisAPL throws without APP_API_BASE_URL, every request 500s). Installed in
+Saleor as app `QXBwOjM=` ("Rover Pay (Stripe sandbox)"), manifest id `app.saleor.stripe` =
+the storefront checkout's `stripeGatewayId`; with a channel mapped, the Stripe card UI
+automatically replaces the PayLater fallback.
+
+**Why its own environment**: Saleor's SSRF guard (`HTTP_IP_FILTER_ENABLED=True`) blocks
+targets resolving to private IPs, and **within an ACA environment every same-env FQDN —
+including custom domains CNAME'd to it — resolves internally**. A custom domain alone does
+NOT help; the app must live in a different environment (or the filter must be disabled).
+Also: Saleor retries `install_app_task` with backoff — a first "Failed to connect to app"
+installation attempt can still succeed ~1 min later, leaving a surprise app registration
+(poll `appsInstallations` until the row disappears rather than failing on first FAILED).
 
 **Stripe sandbox config**: keys in KV — `rovershop-stripe-sandbox-secret-key` (sk_test, the
 app rejects restricted rk_ keys), `-publishable-key` (pk_test), `-api-key` (rk_test, unused by
-this app). Config entry "RoverShop sandbox" is mapped to every channel so all vendors test
-through the shared sandbox; per-vendor Stripe accounts come later. Configuration is scriptable:
-the app's tRPC (`/api/trpc/paymentConfig.add`, `mapping.update`) accepts a Saleor staff JWT via
-`authorization-bearer` + `saleor-api-url` headers (needs MANAGE_APPS + MANAGE_SETTINGS; the
-`Origin` header must be the app URL — it's used to build the auto-created Stripe webhook).
+this app). Config entry "RoverShop sandbox" (Stripe webhook auto-created:
+`we_1TsZPZKCiofHBeSmDeYlhHst`) is mapped to **all three channels** so every vendor transacts
+through the shared sandbox; per-vendor Stripe accounts come later. Config auth gotcha: the
+app's tRPC requires a JWT whose `app` claim matches the app ID — plain admin `tokenCreate`
+JWTs are REJECTED; configure via the admin dashboard UI (its iframe gets app-scoped tokens),
+or capture that token from the iframe's requests and replay tRPC calls
+(`paymentAppConfigurationRouter.paymentConfig.add` / `.mapping.update`; no superjson — raw
+JSON in/out; `Origin` header must be the app URL, it builds the Stripe webhook URL).
+The app's channel-mapping UI shows no rows on self-hosted installs (its channels fetch comes
+back empty) — `mapping.update` works regardless, it only validates the config entry.
+
+**E2E-verified 2026-07-13**: prod storefront checkout with test card 4242→ Stripe
+paymentIntent confirmed → Saleor order **Paid** in the vendor dashboard (orders #9/#10,
+`stripe-e2e@`/`stripe-prod-e2e@example.com`). Full loop: storefront → Stripe Elements →
+rover-pay webhooks → Saleor transaction → dashboard Orders (Fulfill enabled, Mark-as-Paid
+correctly hidden).
 
 **Rover Pay evolution plan**: this container is the seed of Rover Pay (roverpay.ai). Path:
 fork `saleor/saleor-app-payment-stripe` → `rover-pay` repo; keep the transaction-flow webhook

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,83 @@
+# rovershop-saleor-platform — Project Reference
+
+The **Saleor commerce backend** for RoverShop: a fork of Saleor's official `saleor-platform`
+repo, used two ways —
+
+1. **Local development**: the upstream docker-compose stack (API, Dashboard, Postgres, Valkey,
+   Mailpit, Jaeger) — see [README.md](./README.md), unchanged from upstream.
+2. **Production**: Azure Container Apps deployment (`api.rovershop.io`,
+   `admin.rovershop.io`) plus the **vendor provisioning scripts** in `scripts/` — this is the
+   RoverShop-specific part. See [DEPLOYMENT.md](./DEPLOYMENT.md) for the full architecture.
+
+This file is the agent-onboarding reference; current state and next steps live in
+[PROGRESS.md](./PROGRESS.md).
+
+## Ecosystem context
+
+| Repo | Relationship |
+| --- | --- |
+| [rovershop-saleor-storefront](../rovershop-saleor-storefront) | Queries this Saleor's GraphQL API per-tenant (`tenant.saleorChannel` scopes every product/checkout query) |
+| [roverai-strapi-platform](../roverai-strapi-platform) | Vendor record's `saleorChannel` field names the channel this repo provisions; booking services carry `saleorProductVariantId` back-references |
+| [rovershop-dashboard-web](../rovershop-dashboard-web) | Vendor dashboard; reads Saleor data for orders/products views (channel-scoped) |
+
+## Multi-tenancy model (core ADR)
+
+**Channel-per-vendor.** Every vendor gets a dedicated Saleor channel (e.g. `illnails`,
+`deliajewelry`) — never shared with `default-channel` — so a vendor's catalog/pricing/checkout
+never mixes with another's and no later migration is needed. `default-channel` remains the
+fallback for unmatched storefront hosts and carries a small placeholder catalog.
+
+Known ceiling: Saleor isn't designed for thousands of channels in one instance; a sharding
+threshold decision is an open item (storefront PROGRESS §5.5).
+
+## Provisioning scripts (`scripts/`)
+
+`provision-illnails.mjs` (booking vendor, with Strapi service write-back) and
+`provision-deliajewelry.mjs` (commerce vendor + default-channel placeholder catalog). Both are
+the **reference pattern** for onboarding any vendor:
+
+- Plain-fetch GraphQL client + `tokenCreate` admin auth + `assertNoErrors()` helper; admin
+  credentials come from env (sourced from Key Vault `rover-technologies-vault` at invocation).
+- **Idempotent throughout**: check-before-create by slug (channels/categories), by
+  **script-scoped metadata markers** (products — e.g. `deliaCatalogSlug`, `legacySourceId`), and
+  by slug+channel (collections). Reruns update in place.
+- Creates: channel → category → products/variants (with channel listings + prices) →
+  `featured-products-{channel}` collection published to that channel.
+
+### Saleor gotchas encoded in these scripts (learned live — don't relearn)
+
+- **Collections are global, not per-channel**: one slug, one shared product list. Each channel
+  needs its own collection slug (`featured-products` for default, `featured-products-{channel}`
+  otherwise).
+- **`filter: { search }` is unreliable for idempotency** right after creation (search-index
+  lag caused duplicate-create bugs twice). Fetch broadly and match client-side on a metadata
+  marker instead.
+- **`trackInventory: false`** is correct for services/non-physical variants — makes
+  `quantityAvailable` resolve to a large non-blocking number.
+- Mutation payload field names don't always match the mutation name
+  (`productVariantChannelListingUpdate` → `variant`, `collectionChannelListingUpdate` →
+  `collection`) — **introspect, don't guess**.
+- graphql-core rejects non-null variables with defaults (`$q: Int! = 1`) — use nullable with a
+  default (`$q: Int = 1`).
+
+## Production architecture (summary — details in DEPLOYMENT.md)
+
+Container Apps env `rover-ai-env` in `rg-rover-saleor-prod`: `saleor-api` (external,
+`api.rovershop.io`), `saleor-dashboard` (external, `admin.rovershop.io`), `saleor-worker`
+(Celery), `saleor-beat` (exactly 1 replica — scheduled tasks must not double-fire), `valkey`
+(internal). Postgres = Azure Flexible Server `psql-rover-saleor-prod-04` (also hosts the
+`strapi` DB for rover-strapi). Media on Azure Blob (`AzureMediaStorage`), email via SendGrid.
+Migrations/superuser run as manual Container Apps Jobs (`saleor-migrate`,
+`saleor-createsuperuser`) — Saleor does not auto-migrate.
+
+Key infra gotchas: Azure Postgres needs `azure.extensions` allow-listing before migrations;
+`DEBUG=False` requires `ALLOWED_CLIENT_HOSTS` + `SECRET_KEY` or the container crashes at start.
+
+## ADRs / decisions log
+
+1. **Channel-per-vendor** isolation (above).
+2. **Dedicated collection slug per channel** (Saleor collections are global).
+3. **Provisioning as idempotent scripts** (for now) — explicitly slated to become MCP tools or
+   a provisioning portal so onboarding isn't hand-run Node scripts (storefront PROGRESS §3).
+4. **Celery beat isolated at 1 replica**, separate from the scalable worker.
+5. **Shared Postgres server** with rover-strapi (cost), least-privilege roles per database.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
 services:
   api:
     image: ghcr.io/saleor/saleor:3.23
-    container_name: dpr-saleor-api
-    image: ghcr.io/saleor/saleor:3.20
+    container_name: dpr-saleor-api  
     ports:
       - 8000:8000
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.4"
 
 services:
   api:
+    container_name: dpr-saleor-api
     image: ghcr.io/saleor/saleor:3.20
     ports:
       - 8000:8000
@@ -26,12 +27,14 @@ services:
       - ALLOWED_HOSTS=localhost,api
 
   dashboard:
+    container_name: dpr-saleor-dashboard
     image: ghcr.io/saleor/saleor-dashboard:latest
     ports:
       - 9000:80
     restart: unless-stopped
 
   db:
+    container_name: saleor-postgresql
     image: library/postgres:15-alpine
     ports:
       - 5432:5432
@@ -42,8 +45,8 @@ services:
       - saleor-db:/var/lib/postgresql/data
       - ./replica_user.sql:/docker-entrypoint-initdb.d/replica_user.sql
     environment:
-      - POSTGRES_USER=saleor
-      - POSTGRES_PASSWORD=saleor
+      - POSTGRES_USER=d2r_saleor
+      - POSTGRES_PASSWORD=d2r!Saleor
 
   redis:
     image: library/redis:7.0-alpine

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,187 @@
+@description('Environment label, e.g. prod or stage. Used only for tagging.')
+param environmentName string = 'prod'
+
+@description('Azure region for all resources.')
+param location string = 'eastus2'
+
+@description('Name of the Container Apps managed environment.')
+param containerAppsEnvironmentName string = 'rover-ai-env'
+
+@description('Name of the Log Analytics workspace backing the Container Apps environment.')
+param logAnalyticsName string = 'log-rover-saleor-${environmentName}'
+
+@description('Globally-unique Storage Account name for Saleor media (lowercase alphanumeric, max 24 chars).')
+param storageAccountName string
+
+@description('Name of the user-assigned managed identity shared by the Saleor container apps/jobs.')
+param identityName string = 'id-rover-saleor-${environmentName}'
+
+@description('Name of the existing Key Vault holding application secrets.')
+param keyVaultName string = 'rover-technologies-vault'
+
+@description('Resource group of the existing Key Vault (may differ from this deployment\'s resource group).')
+param keyVaultResourceGroup string = 'rover-technologies-rg'
+
+@description('Image tag for ghcr.io/saleor/saleor.')
+param apiImageTag string = '3.23'
+
+@description('Image tag for ghcr.io/saleor/saleor-dashboard.')
+param dashboardImageTag string = '3.23'
+
+@description('Value for ALLOWED_HOSTS, e.g. api.rovershop.io')
+param allowedHosts string
+
+@description('Value for ALLOWED_GRAPHQL_ORIGINS')
+param allowedGraphqlOrigins string = '*'
+
+@description('Value for PUBLIC_URL, e.g. https://api.rovershop.io')
+param publicUrl string
+
+@description('Value for DASHBOARD_URL, e.g. https://admin.rovershop.io')
+param dashboardUrl string
+
+@description('Value for the Dashboard API_URL env var, e.g. https://api.rovershop.io/graphql/')
+param apiGraphqlUrl string
+
+@description('Value for DEFAULT_FROM_EMAIL')
+param defaultFromEmail string
+
+@description('Max replicas for the worker app.')
+param workerMaxReplicas int = 1
+
+@description('Max replicas for the api app.')
+param apiMaxReplicas int = 3
+
+@description('Name of the Azure Postgres Flexible Server.')
+param postgresServerName string = 'psql-rover-saleor-${environmentName}'
+
+@description('Administrator password for the Postgres Flexible Server.')
+@secure()
+param postgresAdminPassword string
+
+@description('Availability zone to pin the Postgres server to (e.g. "1", "2", "3"). Empty string lets Azure auto-select.')
+param postgresAvailabilityZone string = ''
+
+@description('Compute SKU for the Postgres server, e.g. Standard_B1ms or Standard_B2s.')
+param postgresSkuName string = 'Standard_B1ms'
+
+var keyVaultUri = 'https://${keyVaultName}${environment().suffixes.keyvaultDns}/'
+var postgresAdminUsername = 'saleoradmin'
+var postgresDatabaseName = 'saleor'
+var postgresDatabaseUrl = 'postgresql://${postgresAdminUsername}:${uriComponent(postgresAdminPassword)}@${postgres.outputs.fqdn}:5432/${postgresDatabaseName}?sslmode=require'
+
+module logAnalytics 'modules/logAnalytics.bicep' = {
+  name: 'logAnalytics'
+  params: {
+    name: logAnalyticsName
+    location: location
+  }
+}
+
+module containerAppsEnvironment 'modules/containerAppsEnvironment.bicep' = {
+  name: 'containerAppsEnvironment'
+  params: {
+    name: containerAppsEnvironmentName
+    location: location
+    logAnalyticsCustomerId: logAnalytics.outputs.customerId
+    logAnalyticsSharedKey: logAnalytics.outputs.sharedKey
+  }
+}
+
+module storage 'modules/storage.bicep' = {
+  name: 'storage'
+  params: {
+    name: storageAccountName
+    location: location
+  }
+}
+
+module identity 'modules/identity.bicep' = {
+  name: 'identity'
+  params: {
+    name: identityName
+    location: location
+  }
+}
+
+module postgres 'modules/postgres.bicep' = {
+  name: 'postgres'
+  params: {
+    name: postgresServerName
+    location: location
+    adminUsername: postgresAdminUsername
+    adminPassword: postgresAdminPassword
+    databaseName: postgresDatabaseName
+    availabilityZone: postgresAvailabilityZone
+    skuName: postgresSkuName
+  }
+}
+
+// Writes the composed DATABASE_URL into the shared, cross-resource-group Key Vault.
+module postgresSecret 'modules/keyVaultSecret.bicep' = {
+  name: 'postgresSecret'
+  scope: resourceGroup(keyVaultResourceGroup)
+  params: {
+    keyVaultName: keyVaultName
+    secretName: 'saleor-database-url'
+    secretValue: postgresDatabaseUrl
+  }
+}
+
+// Grants the shared identity "Key Vault Secrets User" on the existing vault,
+// which lives in a different resource group.
+module keyVaultAccess 'modules/keyVaultAccess.bicep' = {
+  name: 'keyVaultAccess'
+  scope: resourceGroup(keyVaultResourceGroup)
+  params: {
+    keyVaultName: keyVaultName
+    principalId: identity.outputs.principalId
+  }
+}
+
+module containerApps 'modules/containerApps.bicep' = {
+  name: 'containerApps'
+  params: {
+    environmentId: containerAppsEnvironment.outputs.id
+    location: location
+    identityId: identity.outputs.id
+    keyVaultUri: keyVaultUri
+    storageAccountName: storage.outputs.accountName
+    apiImageTag: apiImageTag
+    dashboardImageTag: dashboardImageTag
+    allowedHosts: allowedHosts
+    allowedGraphqlOrigins: allowedGraphqlOrigins
+    publicUrl: publicUrl
+    dashboardUrl: dashboardUrl
+    apiGraphqlUrl: apiGraphqlUrl
+    defaultFromEmail: defaultFromEmail
+    workerMaxReplicas: workerMaxReplicas
+    apiMaxReplicas: apiMaxReplicas
+  }
+  dependsOn: [
+    keyVaultAccess
+    postgresSecret
+  ]
+}
+
+module jobs 'modules/jobs.bicep' = {
+  name: 'jobs'
+  params: {
+    environmentId: containerAppsEnvironment.outputs.id
+    location: location
+    identityId: identity.outputs.id
+    keyVaultUri: keyVaultUri
+    apiImageTag: apiImageTag
+    storageAccountName: storage.outputs.accountName
+  }
+  dependsOn: [
+    keyVaultAccess
+    postgresSecret
+  ]
+}
+
+output apiFqdn string = containerApps.outputs.apiFqdn
+output postgresFqdn string = postgres.outputs.fqdn
+output dashboardFqdn string = containerApps.outputs.dashboardFqdn
+output identityPrincipalId string = identity.outputs.principalId
+output storageAccountName string = storage.outputs.accountName

--- a/infra/main.parameters.prod.json
+++ b/infra/main.parameters.prod.json
@@ -13,7 +13,7 @@
     "apiImageTag": { "value": "3.23" },
     "dashboardImageTag": { "value": "3.23" },
     "allowedHosts": { "value": "api.rovershop.io,saleor-api.happydune-4b5dd51b.eastus2.azurecontainerapps.io" },
-    "allowedGraphqlOrigins": { "value": "https://admin.rovershop.io" },
+    "allowedGraphqlOrigins": { "value": "https://admin.rovershop.io,https://rovershop.ai,https://*.rovershop.ai,https://deliajewelry.com,https://www.deliajewelry.com,https://*.azurecontainerapps.io,http://localhost:3000" },
     "publicUrl": { "value": "https://api.rovershop.io" },
     "dashboardUrl": { "value": "https://admin.rovershop.io" },
     "apiGraphqlUrl": { "value": "https://api.rovershop.io/graphql/" },

--- a/infra/main.parameters.prod.json
+++ b/infra/main.parameters.prod.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": { "value": "prod" },
+    "location": { "value": "eastus2" },
+    "containerAppsEnvironmentName": { "value": "rover-ai-env" },
+    "logAnalyticsName": { "value": "log-rover-saleor-prod" },
+    "storageAccountName": { "value": "strovershopmediaprod" },
+    "identityName": { "value": "id-rover-saleor-prod" },
+    "keyVaultName": { "value": "rover-technologies-vault" },
+    "keyVaultResourceGroup": { "value": "rover-technologies-rg" },
+    "apiImageTag": { "value": "3.23" },
+    "dashboardImageTag": { "value": "3.23" },
+    "allowedHosts": { "value": "api.rovershop.io,saleor-api.happydune-4b5dd51b.eastus2.azurecontainerapps.io" },
+    "allowedGraphqlOrigins": { "value": "https://admin.rovershop.io" },
+    "publicUrl": { "value": "https://api.rovershop.io" },
+    "dashboardUrl": { "value": "https://admin.rovershop.io" },
+    "apiGraphqlUrl": { "value": "https://api.rovershop.io/graphql/" },
+    "defaultFromEmail": { "value": "noreply@rovershop.io" },
+    "workerMaxReplicas": { "value": 1 },
+    "apiMaxReplicas": { "value": 3 },
+    "postgresServerName": { "value": "psql-rover-saleor-prod-04" },
+    "postgresAvailabilityZone": { "value": "1" },
+    "postgresSkuName": { "value": "Standard_B1ms" }
+  }
+}

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -98,6 +98,8 @@ var commonEnv = [
   { name: 'AZURE_CONTAINER', value: 'media' }
   { name: 'AZURE_ACCOUNT_NAME', value: storageAccountName }
   { name: 'AZURE_ACCOUNT_KEY', secretRef: 'storage-account-key' }
+  // Storage account rejects plain HTTP (AccountRequiresHttps) — Saleor defaults to HTTP without this
+  { name: 'AZURE_SSL', value: 'True' }
 ]
 
 // Internal-only cache/broker. TCP ingress so it's reachable from other apps

--- a/infra/modules/containerApps.bicep
+++ b/infra/modules/containerApps.bicep
@@ -1,0 +1,315 @@
+@description('Resource ID of the Container Apps managed environment.')
+param environmentId string
+
+@description('Azure region.')
+param location string
+
+@description('Resource ID of the user-assigned managed identity used to read Key Vault secrets.')
+param identityId string
+
+@description('Base URI of the Key Vault, e.g. https://rover-technologies-vault.vault.azure.net/')
+param keyVaultUri string
+
+@description('Storage account name used for Saleor media (Azure Blob Storage).')
+param storageAccountName string
+
+@description('Image tag for ghcr.io/saleor/saleor.')
+param apiImageTag string = '3.23'
+
+@description('Image tag for ghcr.io/saleor/saleor-dashboard.')
+param dashboardImageTag string = '3.23'
+
+@description('Value for ALLOWED_HOSTS, e.g. api.rovershop.io')
+param allowedHosts string
+
+@description('Value for ALLOWED_GRAPHQL_ORIGINS')
+param allowedGraphqlOrigins string = '*'
+
+@description('Value for PUBLIC_URL, e.g. https://api.rovershop.io')
+param publicUrl string
+
+@description('Value for DASHBOARD_URL, e.g. https://admin.rovershop.io')
+param dashboardUrl string
+
+@description('Value for the Dashboard API_URL env var, e.g. https://api.rovershop.io/graphql/')
+param apiGraphqlUrl string
+
+@description('Value for DEFAULT_FROM_EMAIL')
+param defaultFromEmail string
+
+@description('Value for DEFAULT_CHANNEL_SLUG')
+param defaultChannelSlug string = 'default-channel'
+
+@description('Max replicas for the worker app (kept at 1 for the initial launch; increase once queue-based autoscaling is tuned).')
+param workerMaxReplicas int = 1
+
+@description('Max replicas for the api app.')
+param apiMaxReplicas int = 3
+
+var identityRef = {
+  '${identityId}': {}
+}
+
+var commonSecrets = [
+  {
+    name: 'database-url'
+    keyVaultUrl: '${keyVaultUri}secrets/saleor-database-url'
+    identity: identityId
+  }
+  {
+    name: 'secret-key'
+    keyVaultUrl: '${keyVaultUri}secrets/saleor-secret-key'
+    identity: identityId
+  }
+  {
+    name: 'email-url'
+    keyVaultUrl: '${keyVaultUri}secrets/rovershop-sendgrid-connection-string'
+    identity: identityId
+  }
+  {
+    name: 'storage-account-key'
+    keyVaultUrl: '${keyVaultUri}secrets/saleor-storage-account-key'
+    identity: identityId
+  }
+  {
+    name: 'rsa-private-key'
+    keyVaultUrl: '${keyVaultUri}secrets/saleor-rsa-private-key'
+    identity: identityId
+  }
+]
+
+var commonEnv = [
+  { name: 'DEBUG', value: 'False' }
+  { name: 'ALLOWED_CLIENT_HOSTS', value: allowedHosts }
+  { name: 'SECRET_KEY', secretRef: 'secret-key' }
+  { name: 'RSA_PRIVATE_KEY', secretRef: 'rsa-private-key' }
+  { name: 'DATABASE_URL', secretRef: 'database-url' }
+  { name: 'EMAIL_URL', secretRef: 'email-url' }
+  { name: 'CACHE_URL', value: 'redis://valkey:6379/0' }
+  { name: 'CELERY_BROKER_URL', value: 'redis://valkey:6379/1' }
+  { name: 'DEFAULT_FROM_EMAIL', value: defaultFromEmail }
+  { name: 'ALLOWED_HOSTS', value: allowedHosts }
+  { name: 'ALLOWED_GRAPHQL_ORIGINS', value: allowedGraphqlOrigins }
+  { name: 'PUBLIC_URL', value: publicUrl }
+  { name: 'DASHBOARD_URL', value: dashboardUrl }
+  { name: 'DEFAULT_CHANNEL_SLUG', value: defaultChannelSlug }
+  { name: 'HTTP_IP_FILTER_ENABLED', value: 'True' }
+  { name: 'HTTP_IP_FILTER_ALLOW_LOOPBACK_IPS', value: 'False' }
+  { name: 'AZURE_CONTAINER', value: 'media' }
+  { name: 'AZURE_ACCOUNT_NAME', value: storageAccountName }
+  { name: 'AZURE_ACCOUNT_KEY', secretRef: 'storage-account-key' }
+]
+
+// Internal-only cache/broker. TCP ingress so it's reachable from other apps
+// in the same environment at "valkey:6379" without being exposed externally.
+resource valkey 'Microsoft.App/containerApps@2023-05-01' = {
+  name: 'valkey'
+  location: location
+  properties: {
+    environmentId: environmentId
+    configuration: {
+      ingress: {
+        external: false
+        targetPort: 6379
+        transport: 'tcp'
+      }
+    }
+    template: {
+      containers: [
+        {
+          name: 'valkey'
+          image: 'docker.io/valkey/valkey:8.1-alpine'
+          resources: {
+            cpu: json('0.25')
+            memory: '0.5Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+}
+
+resource api 'Microsoft.App/containerApps@2023-05-01' = {
+  name: 'saleor-api'
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: identityRef
+  }
+  properties: {
+    environmentId: environmentId
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8000
+        transport: 'auto'
+        allowInsecure: false
+      }
+      secrets: commonSecrets
+    }
+    template: {
+      containers: [
+        {
+          name: 'saleor-api'
+          image: 'ghcr.io/saleor/saleor:${apiImageTag}'
+          resources: {
+            cpu: json('1.0')
+            memory: '2Gi'
+          }
+          env: commonEnv
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: apiMaxReplicas
+        rules: [
+          {
+            name: 'http-scaling'
+            http: {
+              metadata: {
+                concurrentRequests: '50'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+  dependsOn: [
+    valkey
+  ]
+}
+
+resource worker 'Microsoft.App/containerApps@2023-05-01' = {
+  name: 'saleor-worker'
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: identityRef
+  }
+  properties: {
+    environmentId: environmentId
+    configuration: {
+      secrets: commonSecrets
+    }
+    template: {
+      containers: [
+        {
+          name: 'saleor-worker'
+          image: 'ghcr.io/saleor/saleor:${apiImageTag}'
+          command: [
+            'celery'
+          ]
+          args: [
+            '-A'
+            'saleor'
+            '--app=saleor.celeryconf:app'
+            'worker'
+            '--loglevel=info'
+          ]
+          resources: {
+            cpu: json('1.0')
+            memory: '2Gi'
+          }
+          env: commonEnv
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: workerMaxReplicas
+      }
+    }
+  }
+  dependsOn: [
+    valkey
+  ]
+}
+
+// Fixed at exactly 1 replica: celery beat must never run more than one
+// instance at a time or scheduled tasks will fire multiple times.
+resource beat 'Microsoft.App/containerApps@2023-05-01' = {
+  name: 'saleor-beat'
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: identityRef
+  }
+  properties: {
+    environmentId: environmentId
+    configuration: {
+      secrets: commonSecrets
+    }
+    template: {
+      containers: [
+        {
+          name: 'saleor-beat'
+          image: 'ghcr.io/saleor/saleor:${apiImageTag}'
+          command: [
+            'celery'
+          ]
+          args: [
+            '-A'
+            'saleor'
+            '--app=saleor.celeryconf:app'
+            'beat'
+            '--loglevel=info'
+          ]
+          resources: {
+            cpu: json('0.25')
+            memory: '0.5Gi'
+          }
+          env: commonEnv
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+  dependsOn: [
+    valkey
+  ]
+}
+
+resource dashboard 'Microsoft.App/containerApps@2023-05-01' = {
+  name: 'saleor-dashboard'
+  location: location
+  properties: {
+    environmentId: environmentId
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 80
+        transport: 'auto'
+        allowInsecure: false
+      }
+    }
+    template: {
+      containers: [
+        {
+          name: 'saleor-dashboard'
+          image: 'ghcr.io/saleor/saleor-dashboard:${dashboardImageTag}'
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            { name: 'API_URL', value: apiGraphqlUrl }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 2
+      }
+    }
+  }
+}
+
+output apiFqdn string = api.properties.configuration.ingress.fqdn
+output dashboardFqdn string = dashboard.properties.configuration.ingress.fqdn

--- a/infra/modules/containerAppsEnvironment.bicep
+++ b/infra/modules/containerAppsEnvironment.bicep
@@ -1,0 +1,29 @@
+@description('Name of the Container Apps managed environment.')
+param name string
+
+@description('Azure region for the environment.')
+param location string
+
+@description('Log Analytics workspace customer ID.')
+param logAnalyticsCustomerId string
+
+@description('Log Analytics workspace shared key.')
+@secure()
+param logAnalyticsSharedKey string
+
+resource environment 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: name
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsCustomerId
+        sharedKey: logAnalyticsSharedKey
+      }
+    }
+  }
+}
+
+output id string = environment.id
+output defaultDomain string = environment.properties.defaultDomain

--- a/infra/modules/identity.bicep
+++ b/infra/modules/identity.bicep
@@ -1,0 +1,14 @@
+@description('Name of the user-assigned managed identity shared by the Saleor container apps/jobs.')
+param name string
+
+@description('Azure region for the identity.')
+param location string
+
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: name
+  location: location
+}
+
+output id string = identity.id
+output principalId string = identity.properties.principalId
+output clientId string = identity.properties.clientId

--- a/infra/modules/jobs.bicep
+++ b/infra/modules/jobs.bicep
@@ -1,0 +1,152 @@
+@description('Resource ID of the Container Apps managed environment.')
+param environmentId string
+
+@description('Azure region.')
+param location string
+
+@description('Resource ID of the user-assigned managed identity used to read Key Vault secrets.')
+param identityId string
+
+@description('Base URI of the Key Vault, e.g. https://rover-technologies-vault.vault.azure.net/')
+param keyVaultUri string
+
+@description('Image tag for ghcr.io/saleor/saleor.')
+param apiImageTag string = '3.23'
+
+@description('Storage account name used for Saleor media (Azure Blob Storage).')
+param storageAccountName string
+
+var identityRef = {
+  '${identityId}': {}
+}
+
+var commonSecrets = [
+  {
+    name: 'database-url'
+    keyVaultUrl: '${keyVaultUri}secrets/saleor-database-url'
+    identity: identityId
+  }
+  {
+    name: 'secret-key'
+    keyVaultUrl: '${keyVaultUri}secrets/saleor-secret-key'
+    identity: identityId
+  }
+  {
+    name: 'storage-account-key'
+    keyVaultUrl: '${keyVaultUri}secrets/saleor-storage-account-key'
+    identity: identityId
+  }
+]
+
+var commonEnv = [
+  { name: 'SECRET_KEY', secretRef: 'secret-key' }
+  { name: 'DATABASE_URL', secretRef: 'database-url' }
+  { name: 'AZURE_CONTAINER', value: 'media' }
+  { name: 'AZURE_ACCOUNT_NAME', value: storageAccountName }
+  { name: 'AZURE_ACCOUNT_KEY', secretRef: 'storage-account-key' }
+]
+
+// One-off migration job. Trigger manually with:
+//   az containerapp job start --name saleor-migrate --resource-group <rg>
+resource migrateJob 'Microsoft.App/jobs@2023-05-01' = {
+  name: 'saleor-migrate'
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: identityRef
+  }
+  properties: {
+    environmentId: environmentId
+    configuration: {
+      triggerType: 'Manual'
+      replicaTimeout: 1800
+      replicaRetryLimit: 0
+      manualTriggerConfig: {
+        parallelism: 1
+        replicaCompletionCount: 1
+      }
+      secrets: commonSecrets
+    }
+    template: {
+      containers: [
+        {
+          name: 'saleor-migrate'
+          image: 'ghcr.io/saleor/saleor:${apiImageTag}'
+          command: [
+            'python3'
+          ]
+          args: [
+            'manage.py'
+            'migrate'
+          ]
+          resources: {
+            cpu: json('1.0')
+            memory: '2Gi'
+          }
+          env: commonEnv
+        }
+      ]
+    }
+  }
+}
+
+// One-off superuser creation job. Requires saleor-admin-email and
+// saleor-admin-password secrets to exist in Key Vault before running.
+// Trigger manually with:
+//   az containerapp job start --name saleor-createsuperuser --resource-group <rg>
+resource createSuperuserJob 'Microsoft.App/jobs@2023-05-01' = {
+  name: 'saleor-createsuperuser'
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: identityRef
+  }
+  properties: {
+    environmentId: environmentId
+    configuration: {
+      triggerType: 'Manual'
+      replicaTimeout: 600
+      replicaRetryLimit: 0
+      manualTriggerConfig: {
+        parallelism: 1
+        replicaCompletionCount: 1
+      }
+      secrets: union(commonSecrets, [
+        {
+          name: 'admin-email'
+          keyVaultUrl: '${keyVaultUri}secrets/saleor-admin-email'
+          identity: identityId
+        }
+        {
+          name: 'admin-password'
+          keyVaultUrl: '${keyVaultUri}secrets/saleor-admin-password'
+          identity: identityId
+        }
+      ])
+    }
+    template: {
+      containers: [
+        {
+          name: 'saleor-createsuperuser'
+          image: 'ghcr.io/saleor/saleor:${apiImageTag}'
+          command: [
+            'python3'
+          ]
+          args: [
+            'manage.py'
+            'createsuperuser'
+            '--noinput'
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: union(commonEnv, [
+            { name: 'DJANGO_SUPERUSER_EMAIL', secretRef: 'admin-email' }
+            { name: 'DJANGO_SUPERUSER_PASSWORD', secretRef: 'admin-password' }
+          ])
+        }
+      ]
+    }
+  }
+}

--- a/infra/modules/jobs.bicep
+++ b/infra/modules/jobs.bicep
@@ -44,6 +44,8 @@ var commonEnv = [
   { name: 'AZURE_CONTAINER', value: 'media' }
   { name: 'AZURE_ACCOUNT_NAME', value: storageAccountName }
   { name: 'AZURE_ACCOUNT_KEY', secretRef: 'storage-account-key' }
+  // Storage account rejects plain HTTP (AccountRequiresHttps) — Saleor defaults to HTTP without this
+  { name: 'AZURE_SSL', value: 'True' }
 ]
 
 // One-off migration job. Trigger manually with:

--- a/infra/modules/keyVaultAccess.bicep
+++ b/infra/modules/keyVaultAccess.bicep
@@ -1,0 +1,21 @@
+@description('Name of the existing Key Vault (deployed in its own resource group; this module must be deployed with scope: resourceGroup(keyVaultResourceGroup)).')
+param keyVaultName string
+
+@description('Principal ID of the identity to grant "Key Vault Secrets User" access.')
+param principalId string
+
+var keyVaultSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, principalId, keyVaultSecretsUserRoleId)
+  scope: keyVault
+  properties: {
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+  }
+}

--- a/infra/modules/keyVaultSecret.bicep
+++ b/infra/modules/keyVaultSecret.bicep
@@ -1,0 +1,21 @@
+@description('Name of the existing Key Vault (deployed in its own resource group; this module must be deployed with scope: resourceGroup(keyVaultResourceGroup)).')
+param keyVaultName string
+
+@description('Name of the secret to create/update.')
+param secretName string
+
+@description('Value of the secret.')
+@secure()
+param secretValue string
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource secret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: secretName
+  properties: {
+    value: secretValue
+  }
+}

--- a/infra/modules/logAnalytics.bicep
+++ b/infra/modules/logAnalytics.bicep
@@ -1,0 +1,20 @@
+@description('Name of the Log Analytics workspace used by the Container Apps environment.')
+param name string
+
+@description('Azure region for the workspace.')
+param location string
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: name
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+output customerId string = logAnalytics.properties.customerId
+#disable-next-line outputs-should-not-contain-secrets
+output sharedKey string = logAnalytics.listKeys().primarySharedKey

--- a/infra/modules/postgres.bicep
+++ b/infra/modules/postgres.bicep
@@ -1,0 +1,82 @@
+@description('Name of the PostgreSQL Flexible Server (globally unique).')
+param name string
+
+@description('Azure region.')
+param location string
+
+@description('Administrator username for the Postgres server.')
+param adminUsername string = 'saleoradmin'
+
+@description('Administrator password for the Postgres server.')
+@secure()
+param adminPassword string
+
+@description('Name of the application database to create.')
+param databaseName string = 'saleor'
+
+@description('Compute SKU, e.g. Standard_B1ms (Burstable).')
+param skuName string = 'Standard_B1ms'
+
+@description('Compute tier, e.g. Burstable.')
+param skuTier string = 'Burstable'
+
+@description('Postgres major version.')
+param postgresVersion string = '15'
+
+@description('Storage size in GB.')
+param storageSizeGB int = 32
+
+@description('Backup retention in days.')
+param backupRetentionDays int = 7
+
+@description('Availability zone to pin the server to (e.g. "1", "2", "3"). Empty string lets Azure auto-select.')
+param availabilityZone string = ''
+
+resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2023-06-01-preview' = {
+  name: name
+  location: location
+  sku: {
+    name: skuName
+    tier: skuTier
+  }
+  properties: {
+    version: postgresVersion
+    administratorLogin: adminUsername
+    administratorLoginPassword: adminPassword
+    storage: {
+      storageSizeGB: storageSizeGB
+    }
+    backup: {
+      backupRetentionDays: backupRetentionDays
+      geoRedundantBackup: 'Disabled'
+    }
+    highAvailability: {
+      mode: 'Disabled'
+    }
+    network: {
+      publicNetworkAccess: 'Enabled'
+    }
+    availabilityZone: availabilityZone
+  }
+}
+
+// Allows traffic from any Azure-internal IP (Container Apps environments use
+// dynamic outbound IPs, so a per-IP rule isn't practical without a NAT
+// gateway/VNet integration). This is the standard approach for Flexible
+// Server + non-VNet-integrated Container Apps.
+resource allowAzureServices 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2023-06-01-preview' = {
+  parent: postgresServer
+  name: 'AllowAllAzureServices'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+
+resource database 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2023-06-01-preview' = {
+  parent: postgresServer
+  name: databaseName
+}
+
+output fqdn string = postgresServer.properties.fullyQualifiedDomainName
+output serverName string = postgresServer.name

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -1,0 +1,40 @@
+@description('Globally-unique Storage Account name (lowercase alphanumeric, max 24 chars).')
+param name string
+
+@description('Azure region for the storage account.')
+param location string
+
+@description('Blob container name used for Saleor media uploads.')
+param mediaContainerName string = 'media'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: name
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: true
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+// Public read access at the container (blob) level so Saleor-served media URLs work,
+// while the account itself still requires keys/RBAC for management operations.
+resource mediaContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  parent: blobService
+  name: mediaContainerName
+  properties: {
+    publicAccess: 'Blob'
+  }
+}
+
+output accountName string = storageAccount.name
+output id string = storageAccount.id

--- a/scripts/provision-deliajewelry.mjs
+++ b/scripts/provision-deliajewelry.mjs
@@ -1,0 +1,434 @@
+#!/usr/bin/env node
+/**
+ * Provisions:
+ *  1. A dedicated Saleor channel + product catalog for Delia Jewelry
+ *     (commerce-mode vendor, no Strapi service records — unlike illnails'
+ *     booking-mode script, this has no Strapi write-back step).
+ *  2. A small generic placeholder catalog on the existing `default-channel`,
+ *     fixing the storefront's default/fallback homepage (previously had
+ *     zero products/collections).
+ *  3. A `featured-products` Collection per channel, published to that
+ *     channel — required for the storefront's unauthenticated
+ *     ProductListByCollection query to see anything.
+ *
+ * Idempotent throughout: every create step checks for an existing resource
+ * first (by slug for channel/category, by a metadata marker for products,
+ * by slug+channel for collections), so reruns update in place rather than
+ * duplicating data. Metadata keys are script-scoped (`deliaCatalogSlug` /
+ * `defaultCatalogSlug`) so this script's idempotency checks never collide
+ * with provision-illnails.mjs's own `legacySourceId` marker if run against
+ * the same Saleor instance.
+ *
+ * Usage:
+ *   SALEOR_API_URL=https://api.rovershop.io/graphql/ \
+ *   SALEOR_ADMIN_EMAIL=admin@rovershop.io \
+ *   SALEOR_ADMIN_PASSWORD=... \
+ *   node scripts/provision-deliajewelry.mjs
+ */
+
+const SALEOR_API_URL = process.env.SALEOR_API_URL ?? "https://api.rovershop.io/graphql/";
+const SALEOR_ADMIN_EMAIL = requireEnv("SALEOR_ADMIN_EMAIL");
+const SALEOR_ADMIN_PASSWORD = requireEnv("SALEOR_ADMIN_PASSWORD");
+
+const DELIA_JEWELRY_PRODUCTS = [
+	{
+		slug: "classic-chain-necklace",
+		name: "Classic Chain Necklace",
+		price: "68.00",
+		description: "18-inch sterling silver chain with a lobster clasp. Everyday layering piece.",
+	},
+	{
+		slug: "signet-ring",
+		name: "Signet Ring",
+		price: "84.00",
+		description: "Polished sterling silver signet ring with a smooth face, unengraved.",
+	},
+	{
+		slug: "pearl-stud-earrings",
+		name: "Pearl Stud Earrings",
+		price: "42.00",
+		description: "Freshwater pearl studs on sterling silver posts. Hypoallergenic.",
+	},
+	{
+		slug: "cuban-link-bracelet",
+		name: "Cuban Link Bracelet",
+		price: "76.00",
+		description: "7.5-inch sterling silver Cuban link bracelet with a secure clasp.",
+	},
+	{
+		slug: "birthstone-pendant",
+		name: "Birthstone Pendant",
+		price: "58.00",
+		description: "Delicate pendant with a single round-cut birthstone, 16-inch chain included.",
+	},
+	{
+		slug: "huggie-hoop-earrings",
+		name: "Huggie Hoop Earrings",
+		price: "36.00",
+		description: "Small sterling silver huggie hoops, 10mm diameter. Everyday wear.",
+	},
+];
+
+const DEFAULT_CHANNEL_PRODUCTS = [
+	{
+		slug: "classic-logo-tee",
+		name: "Classic Logo Tee",
+		price: "28.00",
+		description: "Soft 100% cotton crewneck tee with a minimal chest logo print. Unisex fit, true to size.",
+	},
+	{
+		slug: "canvas-zip-hoodie",
+		name: "Canvas Zip Hoodie",
+		price: "58.00",
+		description: "Midweight cotton-poly fleece zip hoodie with kangaroo pocket. Everyday layering piece.",
+	},
+	{
+		slug: "everyday-cap",
+		name: "Everyday Cap",
+		price: "24.00",
+		description: "Structured six-panel cap with adjustable strap and embroidered logo. One size fits most.",
+	},
+	{
+		slug: "insulated-steel-tumbler",
+		name: "Insulated Steel Tumbler",
+		price: "22.00",
+		description: "20oz double-wall stainless tumbler, keeps drinks cold 24h / hot 8h. Leak-resistant lid.",
+	},
+	{
+		slug: "canvas-tote-bag",
+		name: "Canvas Tote Bag",
+		price: "18.00",
+		description: "Heavyweight 12oz canvas tote with reinforced handles. Fits a laptop and a day's errands.",
+	},
+	{
+		slug: "ceramic-mug",
+		name: "Ceramic Mug",
+		price: "16.00",
+		description: "12oz glossy ceramic mug, dishwasher and microwave safe.",
+	},
+];
+
+function requireEnv(name) {
+	const value = process.env[name];
+	if (!value) {
+		console.error(`Missing required env var ${name}`);
+		process.exit(1);
+	}
+	return value;
+}
+
+let saleorToken;
+
+async function saleor(query, variables = {}) {
+	const response = await fetch(SALEOR_API_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...(saleorToken ? { Authorization: `Bearer ${saleorToken}` } : {}),
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+	const json = await response.json();
+	if (json.errors) {
+		throw new Error(`Saleor GraphQL error: ${JSON.stringify(json.errors)}`);
+	}
+	return json.data;
+}
+
+function assertNoErrors(result, mutationKey, label) {
+	const errors = result?.[mutationKey]?.errors;
+	if (errors && errors.length > 0) {
+		throw new Error(`${label} failed: ${JSON.stringify(errors)}`);
+	}
+}
+
+function plaintextToEditorJs(text) {
+	if (!text) return null;
+	return JSON.stringify({
+		time: Date.now(),
+		blocks: [{ type: "paragraph", data: { text } }],
+		version: "2.22.2",
+	});
+}
+
+/**
+ * Creates (idempotently) a set of products in a given category, channel-lists
+ * and prices them, and returns their product ids — for use seeding a
+ * `featured-products` collection. Reusable across any channel/category pair.
+ */
+async function provisionProducts({ products, productType, category, channel, metadataKey }) {
+	console.log(`Fetching existing Saleor products for idempotency check (key=${metadataKey})...`);
+	const allProductsResult = await saleor(
+		`{ products(first: 100, filter: {}) { edges { node { id name metadata { key value } defaultVariant { id } variants { id } } } } }`,
+	);
+	const existingProducts = allProductsResult.products.edges.map((e) => e.node);
+
+	const productIds = [];
+
+	for (const item of products) {
+		console.log(`Processing "${item.name}" (${channel.slug})...`);
+
+		let product = existingProducts.find((p) =>
+			p.metadata.some((m) => m.key === metadataKey && m.value === item.slug),
+		);
+
+		if (!product) {
+			const created = await saleor(
+				`mutation($input: ProductCreateInput!) {
+					productCreate(input: $input) {
+						product { id name defaultVariant { id } variants { id } }
+						errors { field message }
+					}
+				}`,
+				{
+					input: {
+						productType: productType.id,
+						category: category.id,
+						name: item.name,
+						slug: item.slug,
+						description: plaintextToEditorJs(item.description),
+						metadata: [{ key: metadataKey, value: item.slug }],
+					},
+				},
+			);
+			assertNoErrors(created, "productCreate", `productCreate(${item.name})`);
+			product = created.productCreate.product;
+			console.log(`  created product ${product.id}`);
+		} else {
+			console.log(`  product already exists: ${product.id}`);
+		}
+
+		let variantId = product.defaultVariant?.id ?? product.variants?.[0]?.id;
+		if (!variantId) {
+			const createdVariant = await saleor(
+				`mutation($input: ProductVariantCreateInput!) {
+					productVariantCreate(input: $input) { productVariant { id } errors { field message } }
+				}`,
+				{ input: { product: product.id, sku: `${channel.slug}-${item.slug}`, trackInventory: false, attributes: [] } },
+			);
+			assertNoErrors(createdVariant, "productVariantCreate", `productVariantCreate(${item.name})`);
+			variantId = createdVariant.productVariantCreate.productVariant.id;
+			console.log(`  created variant ${variantId}`);
+		} else {
+			await saleor(
+				`mutation($id: ID!, $input: ProductVariantInput!) {
+					productVariantUpdate(id: $id, input: $input) { productVariant { id } errors { field message } }
+				}`,
+				{ id: variantId, input: { trackInventory: false } },
+			);
+		}
+
+		const listed = await saleor(
+			`mutation($id: ID!, $input: ProductChannelListingUpdateInput!) {
+				productChannelListingUpdate(id: $id, input: $input) { product { id } errors { field message } }
+			}`,
+			{
+				id: product.id,
+				input: {
+					updateChannels: [
+						{ channelId: channel.id, isPublished: true, visibleInListings: true, isAvailableForPurchase: true },
+					],
+				},
+			},
+		);
+		assertNoErrors(listed, "productChannelListingUpdate", `productChannelListingUpdate(${item.name})`);
+
+		const priced = await saleor(
+			`mutation($id: ID!, $input: [ProductVariantChannelListingAddInput!]!) {
+				productVariantChannelListingUpdate(id: $id, input: $input) { variant { id } errors { field message } }
+			}`,
+			{ id: variantId, input: [{ channelId: channel.id, price: item.price }] },
+		);
+		assertNoErrors(priced, "productVariantChannelListingUpdate", `productVariantChannelListingUpdate(${item.name})`);
+
+		console.log(`  listed + priced at $${item.price} on channel ${channel.slug}`);
+		productIds.push(product.id);
+	}
+
+	return productIds;
+}
+
+/**
+ * Creates (idempotently) a `featured-products`-style collection on the given
+ * channel, seeded with the given product ids, and publishes it to that
+ * channel. Required for the storefront's unauthenticated
+ * ProductListByCollection query to see anything — an unpublished collection
+ * is invisible to anonymous queries even if it exists.
+ *
+ * IMPORTANT: Saleor Collections have one global slug and one shared product
+ * list across every channel they're listed on — a slug is NOT scoped per
+ * channel the way a product's channel listing is (confirmed live: attempting
+ * to create a second "featured-products" collection for a different channel
+ * fails with "Collection with this Slug already exists"). Each channel that
+ * needs its own distinct product set must use its own distinct slug.
+ * `default-channel` keeps the plain `featured-products` slug (matches the
+ * storefront's existing hardcoded literal, used as the fallback/default
+ * tenant experience); every other channel gets `featured-products-<channel>`.
+ */
+async function provisionFeaturedCollection({ channel, productIds, slug }) {
+	console.log(`Ensuring "${slug}" collection exists on channel ${channel.slug}...`);
+	let collection = (
+		await saleor(`query($slug: String!, $channel: String!) { collection(slug: $slug, channel: $channel) { id } }`, {
+			slug,
+			channel: channel.slug,
+		})
+	).collection;
+
+	if (!collection) {
+		const created = await saleor(
+			`mutation($input: CollectionCreateInput!) {
+				collectionCreate(input: $input) { collection { id } errors { field message } }
+			}`,
+			{
+				input: {
+					name: "Featured Products",
+					slug,
+					description: plaintextToEditorJs("A few of our favorites."),
+					products: productIds,
+				},
+			},
+		);
+		assertNoErrors(created, "collectionCreate", `collectionCreate(${channel.slug})`);
+		collection = created.collectionCreate.collection;
+		console.log(`  created collection ${collection.id}`);
+	} else {
+		console.log(`  collection already exists: ${collection.id}`);
+	}
+
+	const published = await saleor(
+		`mutation($id: ID!, $input: CollectionChannelListingUpdateInput!) {
+			collectionChannelListingUpdate(id: $id, input: $input) { collection { id } errors { field message } }
+		}`,
+		{ id: collection.id, input: { addChannels: [{ channelId: channel.id, isPublished: true }] } },
+	);
+	assertNoErrors(published, "collectionChannelListingUpdate", `collectionChannelListingUpdate(${channel.slug})`);
+	console.log(`  published collection to channel ${channel.slug}`);
+}
+
+async function main() {
+	console.log("Authenticating to Saleor...");
+	const tokenResult = await saleor(
+		`mutation TokenCreate($email: String!, $password: String!) {
+			tokenCreate(email: $email, password: $password) { token errors { field message } }
+		}`,
+		{ email: SALEOR_ADMIN_EMAIL, password: SALEOR_ADMIN_PASSWORD },
+	);
+	assertNoErrors(tokenResult, "tokenCreate", "Saleor auth");
+	saleorToken = tokenResult.tokenCreate.token;
+
+	// --- Resolve default-channel (must already exist) ---
+	const defaultChannel = (
+		await saleor(`query { channel(slug: "default-channel") { id slug } }`)
+	).channel;
+	if (!defaultChannel) {
+		throw new Error("default-channel does not exist — expected it to already be provisioned");
+	}
+	console.log(`Resolved default-channel: ${defaultChannel.id}`);
+
+	// --- Ensure deliajewelry channel exists ---
+	console.log(`Ensuring channel "deliajewelry" exists...`);
+	let deliaChannel = (
+		await saleor(`query { channel(slug: "deliajewelry") { id slug } }`)
+	).channel;
+
+	if (!deliaChannel) {
+		const existing = await saleor(
+			`{ warehouses(first: 20) { edges { node { id slug } } } shippingZones(first: 20) { edges { node { id name } } } }`,
+		);
+		const defaultWarehouse = existing.warehouses.edges.find((e) => e.node.slug === "default-warehouse")?.node;
+		const defaultShippingZone = existing.shippingZones.edges.find((e) => e.node.name === "Default")?.node;
+
+		const created = await saleor(
+			`mutation($input: ChannelCreateInput!) {
+				channelCreate(input: $input) { channel { id slug } errors { field message } }
+			}`,
+			{
+				input: {
+					name: "Delia Jewelry",
+					slug: "deliajewelry",
+					currencyCode: "USD",
+					defaultCountry: "US",
+					isActive: true,
+					addWarehouses: defaultWarehouse ? [defaultWarehouse.id] : [],
+					addShippingZones: defaultShippingZone ? [defaultShippingZone.id] : [],
+				},
+			},
+		);
+		assertNoErrors(created, "channelCreate", "channelCreate");
+		deliaChannel = created.channelCreate.channel;
+		console.log(`  created channel ${deliaChannel.id}`);
+	} else {
+		console.log(`  channel already exists: ${deliaChannel.id}`);
+	}
+
+	// --- Resolve Default Type product type (must already exist) ---
+	const productType = (await saleor(`{ productTypes(first: 50) { edges { node { id name } } } }`))
+		.productTypes.edges.map((e) => e.node)
+		.find((pt) => pt.name === "Default Type");
+	if (!productType) {
+		throw new Error('"Default Type" product type not found — expected it to already exist');
+	}
+	console.log(`Resolved product type "Default Type": ${productType.id}`);
+
+	// --- Categories (check-before-create by name) ---
+	const existingCategories = (await saleor(`{ categories(first: 100) { edges { node { id name } } } }`))
+		.categories.edges.map((e) => e.node);
+
+	async function ensureCategory(name) {
+		let category = existingCategories.find((c) => c.name === name);
+		if (!category) {
+			const created = await saleor(
+				`mutation($input: CategoryInput!) {
+					categoryCreate(input: $input) { category { id name } errors { field message } }
+				}`,
+				{ input: { name } },
+			);
+			assertNoErrors(created, "categoryCreate", `categoryCreate(${name})`);
+			category = created.categoryCreate.category;
+			console.log(`  created category "${name}" -> ${category.id}`);
+		} else {
+			console.log(`  category "${name}" already exists: ${category.id}`);
+		}
+		return category;
+	}
+
+	const jewelryCategory = await ensureCategory("Jewelry");
+	const merchandiseCategory = await ensureCategory("Merchandise");
+
+	// --- Delia Jewelry catalog ---
+	const deliaProductIds = await provisionProducts({
+		products: DELIA_JEWELRY_PRODUCTS,
+		productType,
+		category: jewelryCategory,
+		channel: deliaChannel,
+		metadataKey: "deliaCatalogSlug",
+	});
+	await provisionFeaturedCollection({
+		channel: deliaChannel,
+		productIds: deliaProductIds,
+		slug: "featured-products-deliajewelry",
+	});
+
+	// --- default-channel catalog (fixes the storefront's fallback homepage) ---
+	const defaultProductIds = await provisionProducts({
+		products: DEFAULT_CHANNEL_PRODUCTS,
+		productType,
+		category: merchandiseCategory,
+		channel: defaultChannel,
+		metadataKey: "defaultCatalogSlug",
+	});
+	await provisionFeaturedCollection({
+		channel: defaultChannel,
+		productIds: defaultProductIds,
+		slug: "featured-products",
+	});
+
+	console.log("Done.");
+	console.log(`  deliajewelry channel: ${deliaChannel.id}, ${deliaProductIds.length} products`);
+	console.log(`  default-channel: ${defaultChannel.id}, ${defaultProductIds.length} products`);
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/scripts/provision-illnails.mjs
+++ b/scripts/provision-illnails.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+/**
+ * Provisions a dedicated Saleor channel + catalog for a booking-mode vendor
+ * from a flat list of services, and links the resulting variant ids back
+ * into the corresponding Strapi `service` records.
+ *
+ * Idempotent: every create step checks for an existing resource first
+ * (by slug for channel/warehouse/category, by `legacySourceId` metadata for
+ * products), so reruns update in place rather than duplicating data.
+ *
+ * Usage:
+ *   SALEOR_API_URL=https://api.rovershop.io/graphql/ \
+ *   SALEOR_ADMIN_EMAIL=admin@rovershop.io \
+ *   SALEOR_ADMIN_PASSWORD=... \
+ *   STRAPI_API_URL=https://api.roverai.io \
+ *   STRAPI_API_TOKEN=... \
+ *   node scripts/provision-illnails.mjs
+ */
+
+const SALEOR_API_URL = process.env.SALEOR_API_URL ?? "https://api.rovershop.io/graphql/";
+const SALEOR_ADMIN_EMAIL = requireEnv("SALEOR_ADMIN_EMAIL");
+const SALEOR_ADMIN_PASSWORD = requireEnv("SALEOR_ADMIN_PASSWORD");
+const STRAPI_API_URL = process.env.STRAPI_API_URL ?? "https://api.roverai.io";
+const STRAPI_API_TOKEN = requireEnv("STRAPI_API_TOKEN");
+
+const VENDOR_CODE = "illnails";
+const CHANNEL_SLUG = "illnails";
+const CHANNEL_NAME = "Illmatic Nails";
+
+function requireEnv(name) {
+	const value = process.env[name];
+	if (!value) {
+		console.error(`Missing required env var ${name}`);
+		process.exit(1);
+	}
+	return value;
+}
+
+let saleorToken;
+
+async function saleor(query, variables = {}) {
+	const response = await fetch(SALEOR_API_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...(saleorToken ? { Authorization: `Bearer ${saleorToken}` } : {}),
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+	const json = await response.json();
+	if (json.errors) {
+		throw new Error(`Saleor GraphQL error: ${JSON.stringify(json.errors)}`);
+	}
+	return json.data;
+}
+
+async function strapi(path, options = {}) {
+	const response = await fetch(`${STRAPI_API_URL}${path}`, {
+		...options,
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${STRAPI_API_TOKEN}`,
+			...(options.headers ?? {}),
+		},
+	});
+	const json = await response.json();
+	if (!response.ok) {
+		throw new Error(`Strapi ${options.method ?? "GET"} ${path} failed: ${JSON.stringify(json)}`);
+	}
+	return json;
+}
+
+function assertNoErrors(result, mutationKey, label) {
+	const errors = result?.[mutationKey]?.errors;
+	if (errors && errors.length > 0) {
+		throw new Error(`${label} failed: ${JSON.stringify(errors)}`);
+	}
+}
+
+function plaintextToEditorJs(text) {
+	if (!text) return null;
+	return JSON.stringify({
+		time: Date.now(),
+		blocks: [{ type: "paragraph", data: { text } }],
+		version: "2.22.2",
+	});
+}
+
+async function main() {
+	console.log("Authenticating to Saleor...");
+	const tokenResult = await saleor(
+		`mutation TokenCreate($email: String!, $password: String!) {
+			tokenCreate(email: $email, password: $password) { token errors { field message } }
+		}`,
+		{ email: SALEOR_ADMIN_EMAIL, password: SALEOR_ADMIN_PASSWORD },
+	);
+	assertNoErrors(tokenResult, "tokenCreate", "Saleor auth");
+	saleorToken = tokenResult.tokenCreate.token;
+
+	// --- 1. Channel (check-before-create) ---
+	console.log(`Ensuring channel "${CHANNEL_SLUG}" exists...`);
+	let channel = (
+		await saleor(`query($slug: String!) { channel(slug: $slug) { id slug } }`, { slug: CHANNEL_SLUG })
+	).channel;
+
+	if (!channel) {
+		const existing = await saleor(
+			`{ warehouses(first: 20) { edges { node { id slug } } } shippingZones(first: 20) { edges { node { id name } } } }`,
+		);
+		const defaultWarehouse = existing.warehouses.edges.find((e) => e.node.slug === "default-warehouse")?.node;
+		const defaultShippingZone = existing.shippingZones.edges.find((e) => e.node.name === "Default")?.node;
+
+		const created = await saleor(
+			`mutation($input: ChannelCreateInput!) {
+				channelCreate(input: $input) { channel { id slug } errors { field message } }
+			}`,
+			{
+				input: {
+					name: CHANNEL_NAME,
+					slug: CHANNEL_SLUG,
+					currencyCode: "USD",
+					defaultCountry: "US",
+					isActive: true,
+					addWarehouses: defaultWarehouse ? [defaultWarehouse.id] : [],
+					addShippingZones: defaultShippingZone ? [defaultShippingZone.id] : [],
+				},
+			},
+		);
+		assertNoErrors(created, "channelCreate", "channelCreate");
+		channel = created.channelCreate.channel;
+		console.log(`  created channel ${channel.id}`);
+	} else {
+		console.log(`  channel already exists: ${channel.id}`);
+	}
+
+	// --- 2. Product type (check-before-create by name) ---
+	console.log(`Ensuring product type "Nail Service" exists...`);
+	let productType = (await saleor(`{ productTypes(first: 50) { edges { node { id name } } } }`))
+		.productTypes.edges.map((e) => e.node)
+		.find((pt) => pt.name === "Nail Service");
+
+	if (!productType) {
+		const created = await saleor(
+			`mutation($input: ProductTypeInput!) {
+				productTypeCreate(input: $input) { productType { id name } errors { field message } }
+			}`,
+			{ input: { name: "Nail Service", kind: "NORMAL", hasVariants: false, isShippingRequired: false } },
+		);
+		assertNoErrors(created, "productTypeCreate", "productTypeCreate");
+		productType = created.productTypeCreate.productType;
+		console.log(`  created product type ${productType.id}`);
+	} else {
+		console.log(`  product type already exists: ${productType.id}`);
+	}
+
+	// --- 3. Categories (check-before-create by name) ---
+	const categoryNames = ["Full Sets", "Fills", "Pedicures"];
+	const categoryByName = {};
+	const existingCategories = (await saleor(`{ categories(first: 100) { edges { node { id name } } } }`))
+		.categories.edges.map((e) => e.node);
+
+	for (const name of categoryNames) {
+		let category = existingCategories.find((c) => c.name === name);
+		if (!category) {
+			const created = await saleor(
+				`mutation($input: CategoryInput!) {
+					categoryCreate(input: $input) { category { id name } errors { field message } }
+				}`,
+				{ input: { name } },
+			);
+			assertNoErrors(created, "categoryCreate", `categoryCreate(${name})`);
+			category = created.categoryCreate.category;
+			console.log(`  created category "${name}" -> ${category.id}`);
+		} else {
+			console.log(`  category "${name}" already exists: ${category.id}`);
+		}
+		categoryByName[name] = category;
+	}
+
+	// --- 4. Fetch Strapi services for illnails ---
+	console.log("Fetching illnails services from Strapi...");
+	const servicesResponse = await strapi(
+		`/api/services?filters[vendor][vendorCode][$eq]=${VENDOR_CODE}&pagination[pageSize]=100`,
+	);
+	const services = servicesResponse.data;
+	console.log(`  found ${services.length} services`);
+
+	// --- 5. Products + variants + channel listings + inventory (per service) ---
+	// Fetch all existing products once up front and match by metadata
+	// client-side — `filter: { search }` proved unreliable for freshly
+	// created products (search-index lag), causing duplicate creates on
+	// rerun. An unfiltered listing query doesn't have that problem.
+	console.log("Fetching existing Saleor products for idempotency check...");
+	const allProductsResult = await saleor(
+		`{ products(first: 100, filter: {}) { edges { node { id name metadata { key value } defaultVariant { id } variants { id } } } } }`,
+	);
+	const existingProducts = allProductsResult.products.edges.map((e) => e.node);
+
+	const linkBack = [];
+
+	for (const service of services) {
+		const category = categoryByName[service.category];
+		if (!category) {
+			console.warn(`  skipping "${service.name}": unrecognized category "${service.category}"`);
+			continue;
+		}
+
+		console.log(`Processing "${service.name}" (legacySourceId=${service.legacySourceId})...`);
+
+		let product = existingProducts.find((p) =>
+			p.metadata.some((m) => m.key === "legacySourceId" && m.value === String(service.legacySourceId)),
+		);
+
+		if (!product) {
+			const created = await saleor(
+				`mutation($input: ProductCreateInput!) {
+					productCreate(input: $input) {
+						product { id name defaultVariant { id } variants { id } }
+						errors { field message }
+					}
+				}`,
+				{
+					input: {
+						productType: productType.id,
+						category: category.id,
+						name: service.name,
+						description: plaintextToEditorJs(service.description),
+						metadata: [{ key: "legacySourceId", value: String(service.legacySourceId) }],
+					},
+				},
+			);
+			assertNoErrors(created, "productCreate", `productCreate(${service.name})`);
+			product = created.productCreate.product;
+			console.log(`  created product ${product.id}`);
+		} else {
+			console.log(`  product already exists: ${product.id}`);
+		}
+
+		let variantId = product.defaultVariant?.id ?? product.variants?.[0]?.id;
+		if (!variantId) {
+			const createdVariant = await saleor(
+				`mutation($input: ProductVariantCreateInput!) {
+					productVariantCreate(input: $input) { productVariant { id } errors { field message } }
+				}`,
+				{
+					input: {
+						product: product.id,
+						sku: `${VENDOR_CODE}-${service.slug}`,
+						trackInventory: false,
+						attributes: [],
+					},
+				},
+			);
+			assertNoErrors(createdVariant, "productVariantCreate", `productVariantCreate(${service.name})`);
+			variantId = createdVariant.productVariantCreate.productVariant.id;
+			console.log(`  created variant ${variantId}`);
+		} else {
+			// Ensure trackInventory is set correctly even on the auto-created default variant.
+			await saleor(
+				`mutation($id: ID!, $input: ProductVariantInput!) {
+					productVariantUpdate(id: $id, input: $input) { productVariant { id } errors { field message } }
+				}`,
+				{ id: variantId, input: { trackInventory: false } },
+			);
+		}
+
+		// Publish product to the illnails channel.
+		const listed = await saleor(
+			`mutation($id: ID!, $input: ProductChannelListingUpdateInput!) {
+				productChannelListingUpdate(id: $id, input: $input) { product { id } errors { field message } }
+			}`,
+			{
+				id: product.id,
+				input: {
+					updateChannels: [
+						{
+							channelId: channel.id,
+							isPublished: true,
+							visibleInListings: true,
+							isAvailableForPurchase: true,
+						},
+					],
+				},
+			},
+		);
+		assertNoErrors(listed, "productChannelListingUpdate", `productChannelListingUpdate(${service.name})`);
+
+		// Set variant price on the illnails channel.
+		const priced = await saleor(
+			`mutation($id: ID!, $input: [ProductVariantChannelListingAddInput!]!) {
+				productVariantChannelListingUpdate(id: $id, input: $input) { variant { id } errors { field message } }
+			}`,
+			{ id: variantId, input: [{ channelId: channel.id, price: String(service.basePrice) }] },
+		);
+		assertNoErrors(priced, "productVariantChannelListingUpdate", `productVariantChannelListingUpdate(${service.name})`);
+
+		console.log(`  listed + priced at $${service.basePrice} on channel ${CHANNEL_SLUG}`);
+		linkBack.push({ documentId: service.documentId, variantId });
+	}
+
+	// --- 6. Link Saleor variant ids back into Strapi ---
+	console.log("Writing saleorProductVariantId back to Strapi...");
+	for (const { documentId, variantId } of linkBack) {
+		await strapi(`/api/services/${documentId}`, {
+			method: "PUT",
+			body: JSON.stringify({ data: { saleorProductVariantId: variantId } }),
+		});
+		console.log(`  updated service ${documentId} -> ${variantId}`);
+	}
+
+	// --- 7. Update vendor.saleorChannel to point at the dedicated channel ---
+	console.log("Updating vendor.saleorChannel...");
+	const vendorResponse = await strapi(`/api/vendors?filters[vendorCode][$eq]=${VENDOR_CODE}`);
+	const vendor = vendorResponse.data[0];
+	if (vendor && vendor.saleorChannel !== CHANNEL_SLUG) {
+		await strapi(`/api/vendors/${vendor.documentId}`, {
+			method: "PUT",
+			body: JSON.stringify({ data: { saleorChannel: CHANNEL_SLUG } }),
+		});
+		console.log(`  updated vendor.saleorChannel: "${vendor.saleorChannel}" -> "${CHANNEL_SLUG}"`);
+	} else {
+		console.log(`  vendor.saleorChannel already "${CHANNEL_SLUG}"`);
+	}
+
+	console.log("Done.");
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/scripts/provision-roverchat-bytes.mjs
+++ b/scripts/provision-roverchat-bytes.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * Provisions the RoverChat "Bytes (⬡) top-up" products on the existing
+ * `roverchat` Saleor channel (#61, epic #56). These are ONE-TIME purchases that,
+ * on ORDER_CREATED, CREDIT the buyer's Bytes wallet rather than provisioning or
+ * upgrading a subscription — see roverai-strapi-platform's webhook receiver, which
+ * detects `roverstoreProduct: 'chat-tokens'` + `roverstoreBytes` and enqueues the
+ * `credit-chat-bytes-from-order` task.
+ *
+ * Package pricing is the SINGLE source of truth in the dashboard
+ * (roverchat-dashboard-web: src/lib/bytes-packages.ts) — keep PACKAGES below in
+ * sync with it. Priced to beat Poe ($30/1M compute points) while staying cost-safe
+ * on gpt-5; Bytes never expire.
+ *
+ * Idempotent throughout: every step checks for an existing resource first, and
+ * products are matched by their `roverstoreBytes` metadata marker (NOT a search
+ * filter — this Saleor instance has documented index lag; see the other provision
+ * scripts). Safe to re-run; it updates price/metadata on an existing product.
+ *
+ * Usage:
+ *   SALEOR_API_URL=https://api.rovershop.io/graphql/ \
+ *   SALEOR_ADMIN_EMAIL=... SALEOR_ADMIN_PASSWORD=... \
+ *   node scripts/provision-roverchat-bytes.mjs
+ */
+
+const SALEOR_API_URL = process.env.SALEOR_API_URL ?? "https://api.rovershop.io/graphql/";
+const SALEOR_ADMIN_EMAIL = requireEnv("SALEOR_ADMIN_EMAIL");
+const SALEOR_ADMIN_PASSWORD = requireEnv("SALEOR_ADMIN_PASSWORD");
+
+const CHANNEL_SLUG = "roverchat"; // the existing ROVERCHAT channel (chat.rovershop.ai)
+const PRODUCT_META_PRODUCT = "roverstoreProduct"; // = "chat-tokens" for all top-ups
+const PRODUCT_META_BYTES = "roverstoreBytes"; // the credited Bytes amount (idempotency marker)
+
+// Keep in sync with roverchat-dashboard-web/src/lib/bytes-packages.ts.
+const PACKAGES = [
+	{ id: "snack", name: "5,000 Bytes ⬡", bytes: 5000, price: "4.99", blurb: "A quick top-up — about 500K tokens of chat." },
+	{ id: "fuel", name: "15,000 Bytes ⬡", bytes: 15000, price: "11.99", blurb: "Best value — about 1.5M tokens. Most popular." },
+	{ id: "power", name: "40,000 Bytes ⬡", bytes: 40000, price: "27.99", blurb: "For power users — about 4M tokens of chat." },
+	{ id: "mega", name: "100,000 Bytes ⬡", bytes: 100000, price: "59.99", blurb: "Maximum headroom — about 10M tokens. Bytes never expire." },
+];
+
+function requireEnv(name) {
+	const value = process.env[name];
+	if (!value) {
+		console.error(`Missing required env var ${name}`);
+		process.exit(1);
+	}
+	return value;
+}
+
+let saleorToken;
+
+async function saleor(query, variables = {}) {
+	const response = await fetch(SALEOR_API_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...(saleorToken ? { Authorization: `Bearer ${saleorToken}` } : {}),
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+	const json = await response.json();
+	if (json.errors) throw new Error(`Saleor GraphQL error: ${JSON.stringify(json.errors)}`);
+	return json.data;
+}
+
+function assertNoErrors(result, mutationKey, label) {
+	const errors = result?.[mutationKey]?.errors;
+	if (errors && errors.length > 0) throw new Error(`${label} failed: ${JSON.stringify(errors)}`);
+}
+
+function plaintextToEditorJs(text) {
+	if (!text) return null;
+	return JSON.stringify({ time: Date.now(), blocks: [{ type: "paragraph", data: { text } }], version: "2.22.2" });
+}
+
+async function main() {
+	console.log("Authenticating to Saleor...");
+	const tokenResult = await saleor(
+		`mutation TokenCreate($email: String!, $password: String!) {
+			tokenCreate(email: $email, password: $password) { token errors { field message } }
+		}`,
+		{ email: SALEOR_ADMIN_EMAIL, password: SALEOR_ADMIN_PASSWORD },
+	);
+	assertNoErrors(tokenResult, "tokenCreate", "Saleor auth");
+	saleorToken = tokenResult.tokenCreate.token;
+
+	// --- 1. Channel (must already exist — the ROVERCHAT channel) ---
+	const channel = (await saleor(`query($slug: String!) { channel(slug: $slug) { id slug } }`, { slug: CHANNEL_SLUG })).channel;
+	if (!channel) throw new Error(`Channel "${CHANNEL_SLUG}" not found — expected the existing ROVERCHAT channel`);
+	console.log(`Using channel ${channel.slug} (${channel.id})`);
+
+	// --- 2. Product type (non-shippable, no variants) ---
+	console.log(`Ensuring product type "Bytes Top-Up" exists...`);
+	let productType = (await saleor(`{ productTypes(first: 100) { edges { node { id name } } } }`)).productTypes.edges
+		.map((e) => e.node)
+		.find((pt) => pt.name === "Bytes Top-Up");
+	if (!productType) {
+		const created = await saleor(
+			`mutation($input: ProductTypeInput!) { productTypeCreate(input: $input) { productType { id name } errors { field message } } }`,
+			{ input: { name: "Bytes Top-Up", kind: "NORMAL", hasVariants: false, isShippingRequired: false } },
+		);
+		assertNoErrors(created, "productTypeCreate", "productTypeCreate");
+		productType = created.productTypeCreate.productType;
+		console.log(`  created product type ${productType.id}`);
+	} else {
+		console.log(`  product type already exists: ${productType.id}`);
+	}
+
+	// --- 3. Category ---
+	console.log(`Ensuring category "Bytes" exists...`);
+	let category = (await saleor(`{ categories(first: 100) { edges { node { id name } } } }`)).categories.edges
+		.map((e) => e.node)
+		.find((c) => c.name === "Bytes");
+	if (!category) {
+		const created = await saleor(
+			`mutation($input: CategoryInput!) { categoryCreate(input: $input) { category { id name } errors { field message } } }`,
+			{ input: { name: "Bytes" } },
+		);
+		assertNoErrors(created, "categoryCreate", "categoryCreate");
+		category = created.categoryCreate.category;
+		console.log(`  created category ${category.id}`);
+	} else {
+		console.log(`  category already exists: ${category.id}`);
+	}
+
+	// --- 4. Products (idempotent by roverstoreBytes metadata) ---
+	console.log("Fetching existing products for idempotency check...");
+	const existingProducts = (
+		await saleor(`{ products(first: 100, filter: {}) { edges { node { id name metadata { key value } defaultVariant { id } variants { id } } } } }`)
+	).products.edges.map((e) => e.node);
+
+	const productIds = [];
+	for (const item of PACKAGES) {
+		console.log(`Processing "${item.name}" (${item.bytes} Bytes)...`);
+		const bytesStr = String(item.bytes);
+		const metadata = [
+			{ key: PRODUCT_META_PRODUCT, value: "chat-tokens" },
+			{ key: PRODUCT_META_BYTES, value: bytesStr },
+		];
+
+		let product = existingProducts.find((p) =>
+			p.metadata.some((m) => m.key === PRODUCT_META_BYTES && m.value === bytesStr) &&
+			p.metadata.some((m) => m.key === PRODUCT_META_PRODUCT && m.value === "chat-tokens"),
+		);
+
+		if (!product) {
+			const created = await saleor(
+				`mutation($input: ProductCreateInput!) {
+					productCreate(input: $input) { product { id name defaultVariant { id } variants { id } } errors { field message } }
+				}`,
+				{
+					input: {
+						productType: productType.id,
+						category: category.id,
+						name: item.name,
+						slug: `rc-bytes-${item.id}`,
+						description: plaintextToEditorJs(item.blurb),
+						metadata,
+					},
+				},
+			);
+			assertNoErrors(created, "productCreate", `productCreate(${item.name})`);
+			product = created.productCreate.product;
+			console.log(`  created product ${product.id}`);
+		} else {
+			// Keep metadata current on a re-run (e.g. bytes/price change).
+			await saleor(
+				`mutation($id: ID!, $input: [MetadataInput!]!) { updateMetadata(id: $id, input: $input) { errors { field message } } }`,
+				{ id: product.id, input: metadata },
+			);
+			console.log(`  product already exists: ${product.id} (metadata refreshed)`);
+		}
+
+		// Variant (single, no inventory tracking).
+		let variantId = product.defaultVariant?.id ?? product.variants?.[0]?.id;
+		if (!variantId) {
+			const createdVariant = await saleor(
+				`mutation($input: ProductVariantCreateInput!) { productVariantCreate(input: $input) { productVariant { id } errors { field message } } }`,
+				{ input: { product: product.id, sku: `rc-bytes-${item.id}`, trackInventory: false, attributes: [] } },
+			);
+			assertNoErrors(createdVariant, "productVariantCreate", `productVariantCreate(${item.name})`);
+			variantId = createdVariant.productVariantCreate.productVariant.id;
+			console.log(`  created variant ${variantId}`);
+		} else {
+			await saleor(
+				`mutation($id: ID!, $input: ProductVariantInput!) { productVariantUpdate(id: $id, input: $input) { productVariant { id } errors { field message } } }`,
+				{ id: variantId, input: { trackInventory: false } },
+			);
+		}
+
+		// Publish on the channel + purchasable.
+		const listed = await saleor(
+			`mutation($id: ID!, $input: ProductChannelListingUpdateInput!) { productChannelListingUpdate(id: $id, input: $input) { product { id } errors { field message } } }`,
+			{ id: product.id, input: { updateChannels: [{ channelId: channel.id, isPublished: true, visibleInListings: true, isAvailableForPurchase: true }] } },
+		);
+		assertNoErrors(listed, "productChannelListingUpdate", `productChannelListingUpdate(${item.name})`);
+
+		// Price.
+		const priced = await saleor(
+			`mutation($id: ID!, $input: [ProductVariantChannelListingAddInput!]!) { productVariantChannelListingUpdate(id: $id, input: $input) { variant { id } errors { field message } } }`,
+			{ id: variantId, input: [{ channelId: channel.id, price: item.price }] },
+		);
+		assertNoErrors(priced, "productVariantChannelListingUpdate", `productVariantChannelListingUpdate(${item.name})`);
+
+		console.log(`  listed + priced at $${item.price} on channel ${CHANNEL_SLUG} (grants ${item.bytes} Bytes)`);
+		productIds.push(product.id);
+	}
+
+	console.log(`\nDone. ${PACKAGES.length} Bytes top-up products live on the "${CHANNEL_SLUG}" channel.`);
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/provision-rovershop-subscriptions.mjs
+++ b/scripts/provision-rovershop-subscriptions.mjs
@@ -1,0 +1,413 @@
+#!/usr/bin/env node
+/**
+ * Provisions RoverShop's own subscription-tier catalog (Starter/Pro/
+ * Enterprise) on a dedicated `rovershop` Saleor channel — the products that,
+ * once purchased via checkout, trigger automatic new-vendor provisioning
+ * (see roverai-strapi-platform's ORDER_CREATED webhook receiver +
+ * `provision-vendor-from-order` task, added alongside this script).
+ *
+ * The `rovershop` channel corresponds to the existing `rovershop`
+ * platform-admin vendor in Strapi (store.rovershop.ai) — its
+ * `vendor.saleorChannel` field already says "rovershop", but the Saleor
+ * channel itself was never actually created; this script creates it.
+ *
+ * Each product carries a `roverstoreSubscriptionTier` metadata marker
+ * (idempotency key AND the field the order-webhook handler reads to
+ * determine which tier a completed order purchased). Idempotent throughout:
+ * every create step checks for an existing resource first (by slug for
+ * channel/product-type/category, by this metadata marker for products —
+ * NOT by search filter, which has documented index lag in this Saleor
+ * instance per provision-illnails.mjs/provision-deliajewelry.mjs).
+ *
+ * Also adds a $0 shipping-method-channel-listing for the new channel even
+ * though the product type is non-shippable — defensive insurance against
+ * the documented "Almost done…" checkout hang incident (see PROGRESS.md)
+ * that hit two prior channel launches; whether it's actually required for a
+ * non-shippable product type is unverified, so this errs toward safety.
+ *
+ * Usage:
+ *   SALEOR_API_URL=https://api.rovershop.io/graphql/ \
+ *   SALEOR_ADMIN_EMAIL=admin@rovershop.io \
+ *   SALEOR_ADMIN_PASSWORD=... \
+ *   STRAPI_API_URL=https://api.roverai.io \
+ *   STRAPI_API_TOKEN=... \
+ *   node scripts/provision-rovershop-subscriptions.mjs
+ */
+
+const SALEOR_API_URL = process.env.SALEOR_API_URL ?? "https://api.rovershop.io/graphql/";
+const SALEOR_ADMIN_EMAIL = requireEnv("SALEOR_ADMIN_EMAIL");
+const SALEOR_ADMIN_PASSWORD = requireEnv("SALEOR_ADMIN_PASSWORD");
+const STRAPI_API_URL = process.env.STRAPI_API_URL ?? "https://api.roverai.io";
+const STRAPI_API_TOKEN = requireEnv("STRAPI_API_TOKEN");
+
+const CHANNEL_SLUG = "rovershop";
+const CHANNEL_NAME = "RoverShop";
+const METADATA_KEY = "roverstoreSubscriptionTier";
+
+// Pricing benchmarked against Shopify/BigCommerce's converged 3-tier market
+// anchor (Basic ~$29-39, Grow ~$79-105, Advanced ~$299-399/mo); Squarespace
+// is priced well below this and isn't the benchmark. See roverai-strapi
+// vendor-from-order-provisioning.ts for the matching FeatureFlags mapping.
+const TIERS = [
+	{
+		tier: "starter",
+		slug: "rovershop-starter",
+		name: "RoverStore Starter",
+		price: "29.00",
+		description:
+			"Everything you need to launch a real online store — products, checkout, and a beautiful storefront in minutes.",
+	},
+	{
+		tier: "pro",
+		slug: "rovershop-pro",
+		name: "RoverStore Pro",
+		price: "79.00",
+		description:
+			"For growing stores: your own domain, gift cards, a team of staff accounts, and SEO tools to bring in more customers.",
+	},
+	{
+		tier: "enterprise",
+		slug: "rovershop-enterprise",
+		name: "RoverStore Enterprise",
+		price: "299.00",
+		description:
+			"The full platform: premium storefront templates, SMS customer reminders, recurring subscription billing, and every feature unlocked.",
+	},
+];
+
+function requireEnv(name) {
+	const value = process.env[name];
+	if (!value) {
+		console.error(`Missing required env var ${name}`);
+		process.exit(1);
+	}
+	return value;
+}
+
+let saleorToken;
+
+async function saleor(query, variables = {}) {
+	const response = await fetch(SALEOR_API_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...(saleorToken ? { Authorization: `Bearer ${saleorToken}` } : {}),
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+	const json = await response.json();
+	if (json.errors) {
+		throw new Error(`Saleor GraphQL error: ${JSON.stringify(json.errors)}`);
+	}
+	return json.data;
+}
+
+async function strapi(path, options = {}) {
+	const response = await fetch(`${STRAPI_API_URL}${path}`, {
+		...options,
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${STRAPI_API_TOKEN}`,
+			...(options.headers ?? {}),
+		},
+	});
+	const json = await response.json();
+	if (!response.ok) {
+		throw new Error(`Strapi ${options.method ?? "GET"} ${path} failed: ${JSON.stringify(json)}`);
+	}
+	return json;
+}
+
+function assertNoErrors(result, mutationKey, label) {
+	const errors = result?.[mutationKey]?.errors;
+	if (errors && errors.length > 0) {
+		throw new Error(`${label} failed: ${JSON.stringify(errors)}`);
+	}
+}
+
+function plaintextToEditorJs(text) {
+	if (!text) return null;
+	return JSON.stringify({
+		time: Date.now(),
+		blocks: [{ type: "paragraph", data: { text } }],
+		version: "2.22.2",
+	});
+}
+
+async function main() {
+	console.log("Authenticating to Saleor...");
+	const tokenResult = await saleor(
+		`mutation TokenCreate($email: String!, $password: String!) {
+			tokenCreate(email: $email, password: $password) { token errors { field message } }
+		}`,
+		{ email: SALEOR_ADMIN_EMAIL, password: SALEOR_ADMIN_PASSWORD },
+	);
+	assertNoErrors(tokenResult, "tokenCreate", "Saleor auth");
+	saleorToken = tokenResult.tokenCreate.token;
+
+	// --- 1. Channel (check-before-create) ---
+	console.log(`Ensuring channel "${CHANNEL_SLUG}" exists...`);
+	let channel = (
+		await saleor(`query($slug: String!) { channel(slug: $slug) { id slug } }`, { slug: CHANNEL_SLUG })
+	).channel;
+
+	if (!channel) {
+		const existing = await saleor(
+			`{ warehouses(first: 20) { edges { node { id slug } } } shippingZones(first: 20) { edges { node { id name } } } }`,
+		);
+		const defaultWarehouse = existing.warehouses.edges.find((e) => e.node.slug === "default-warehouse")?.node;
+		const defaultShippingZone = existing.shippingZones.edges.find((e) => e.node.name === "Default")?.node;
+
+		const created = await saleor(
+			`mutation($input: ChannelCreateInput!) {
+				channelCreate(input: $input) { channel { id slug } errors { field message } }
+			}`,
+			{
+				input: {
+					name: CHANNEL_NAME,
+					slug: CHANNEL_SLUG,
+					currencyCode: "USD",
+					defaultCountry: "US",
+					isActive: true,
+					addWarehouses: defaultWarehouse ? [defaultWarehouse.id] : [],
+					addShippingZones: defaultShippingZone ? [defaultShippingZone.id] : [],
+				},
+			},
+		);
+		assertNoErrors(created, "channelCreate", "channelCreate");
+		channel = created.channelCreate.channel;
+		console.log(`  created channel ${channel.id}`);
+	} else {
+		console.log(`  channel already exists: ${channel.id}`);
+	}
+
+	// --- 1b. Defensive $0 shipping-method-channel-listing (see file header) ---
+	console.log("Ensuring a shipping method is listed on this channel...");
+	const shippingZones = (
+		await saleor(`{ shippingZones(first: 20) { edges { node { id name shippingMethods { id name } } } } }`)
+	).shippingZones.edges.map((e) => e.node);
+	const defaultZone = shippingZones.find((z) => z.name === "Default");
+	const defaultMethod = defaultZone?.shippingMethods?.[0];
+	if (defaultMethod) {
+		const listed = await saleor(
+			`mutation($id: ID!, $input: ShippingMethodChannelListingInput!) {
+				shippingMethodChannelListingUpdate(id: $id, input: $input) {
+					shippingMethod { id }
+					errors { field message }
+				}
+			}`,
+			{ id: defaultMethod.id, input: { addChannels: [{ channelId: channel.id, price: "0" }] } },
+		);
+		assertNoErrors(listed, "shippingMethodChannelListingUpdate", "shippingMethodChannelListingUpdate");
+		console.log(`  listed shipping method ${defaultMethod.id} on channel at $0`);
+	} else {
+		console.warn("  no default shipping method found — skipping (checkout may fail if one is actually required)");
+	}
+
+	// --- 2. Product type (check-before-create by name) ---
+	console.log(`Ensuring product type "Subscription Plan" exists...`);
+	let productType = (await saleor(`{ productTypes(first: 50) { edges { node { id name } } } }`))
+		.productTypes.edges.map((e) => e.node)
+		.find((pt) => pt.name === "Subscription Plan");
+
+	if (!productType) {
+		const created = await saleor(
+			`mutation($input: ProductTypeInput!) {
+				productTypeCreate(input: $input) { productType { id name } errors { field message } }
+			}`,
+			{ input: { name: "Subscription Plan", kind: "NORMAL", hasVariants: false, isShippingRequired: false } },
+		);
+		assertNoErrors(created, "productTypeCreate", "productTypeCreate");
+		productType = created.productTypeCreate.productType;
+		console.log(`  created product type ${productType.id}`);
+	} else {
+		console.log(`  product type already exists: ${productType.id}`);
+	}
+
+	// --- 3. Category (check-before-create by name) ---
+	console.log(`Ensuring category "Plans" exists...`);
+	let category = (await saleor(`{ categories(first: 100) { edges { node { id name } } } }`))
+		.categories.edges.map((e) => e.node)
+		.find((c) => c.name === "Plans");
+
+	if (!category) {
+		const created = await saleor(
+			`mutation($input: CategoryInput!) {
+				categoryCreate(input: $input) { category { id name } errors { field message } }
+			}`,
+			{ input: { name: "Plans" } },
+		);
+		assertNoErrors(created, "categoryCreate", "categoryCreate");
+		category = created.categoryCreate.category;
+		console.log(`  created category ${category.id}`);
+	} else {
+		console.log(`  category already exists: ${category.id}`);
+	}
+
+	// --- 4. Products + variants + channel listings + pricing (per tier) ---
+	// Fetch all existing products once up front and match by metadata
+	// client-side — search-filter idempotency checks have documented index
+	// lag in this Saleor instance (see provision-illnails.mjs).
+	console.log("Fetching existing Saleor products for idempotency check...");
+	const allProductsResult = await saleor(
+		`{ products(first: 100, filter: {}) { edges { node { id name metadata { key value } defaultVariant { id } variants { id } } } } }`,
+	);
+	const existingProducts = allProductsResult.products.edges.map((e) => e.node);
+
+	const productIds = [];
+
+	for (const item of TIERS) {
+		console.log(`Processing "${item.name}" (${item.tier})...`);
+
+		let product = existingProducts.find((p) =>
+			p.metadata.some((m) => m.key === METADATA_KEY && m.value === item.tier),
+		);
+
+		if (!product) {
+			const created = await saleor(
+				`mutation($input: ProductCreateInput!) {
+					productCreate(input: $input) {
+						product { id name defaultVariant { id } variants { id } }
+						errors { field message }
+					}
+				}`,
+				{
+					input: {
+						productType: productType.id,
+						category: category.id,
+						name: item.name,
+						slug: item.slug,
+						description: plaintextToEditorJs(item.description),
+						metadata: [{ key: METADATA_KEY, value: item.tier }],
+					},
+				},
+			);
+			assertNoErrors(created, "productCreate", `productCreate(${item.name})`);
+			product = created.productCreate.product;
+			console.log(`  created product ${product.id}`);
+		} else {
+			console.log(`  product already exists: ${product.id}`);
+		}
+
+		let variantId = product.defaultVariant?.id ?? product.variants?.[0]?.id;
+		if (!variantId) {
+			const createdVariant = await saleor(
+				`mutation($input: ProductVariantCreateInput!) {
+					productVariantCreate(input: $input) { productVariant { id } errors { field message } }
+				}`,
+				{ input: { product: product.id, sku: `rovershop-${item.tier}`, trackInventory: false, attributes: [] } },
+			);
+			assertNoErrors(createdVariant, "productVariantCreate", `productVariantCreate(${item.name})`);
+			variantId = createdVariant.productVariantCreate.productVariant.id;
+			console.log(`  created variant ${variantId}`);
+		} else {
+			await saleor(
+				`mutation($id: ID!, $input: ProductVariantInput!) {
+					productVariantUpdate(id: $id, input: $input) { productVariant { id } errors { field message } }
+				}`,
+				{ id: variantId, input: { trackInventory: false } },
+			);
+		}
+
+		const listed = await saleor(
+			`mutation($id: ID!, $input: ProductChannelListingUpdateInput!) {
+				productChannelListingUpdate(id: $id, input: $input) { product { id } errors { field message } }
+			}`,
+			{
+				id: product.id,
+				input: {
+					updateChannels: [
+						{ channelId: channel.id, isPublished: true, visibleInListings: true, isAvailableForPurchase: true },
+					],
+				},
+			},
+		);
+		assertNoErrors(listed, "productChannelListingUpdate", `productChannelListingUpdate(${item.name})`);
+
+		const priced = await saleor(
+			`mutation($id: ID!, $input: [ProductVariantChannelListingAddInput!]!) {
+				productVariantChannelListingUpdate(id: $id, input: $input) { variant { id } errors { field message } }
+			}`,
+			{ id: variantId, input: [{ channelId: channel.id, price: item.price }] },
+		);
+		assertNoErrors(priced, "productVariantChannelListingUpdate", `productVariantChannelListingUpdate(${item.name})`);
+
+		console.log(`  listed + priced at $${item.price}/mo on channel ${CHANNEL_SLUG}`);
+		productIds.push(product.id);
+	}
+
+	// --- 5. Featured collection (channel-specific slug — Saleor collection
+	// slugs are global across channels, confirmed in provision-deliajewelry.mjs) ---
+	const collectionSlug = `featured-products-${CHANNEL_SLUG}`;
+	console.log(`Ensuring "${collectionSlug}" collection exists on channel ${CHANNEL_SLUG}...`);
+	let collection = (
+		await saleor(`query($slug: String!, $channel: String!) { collection(slug: $slug, channel: $channel) { id } }`, {
+			slug: collectionSlug,
+			channel: CHANNEL_SLUG,
+		})
+	).collection;
+
+	if (!collection) {
+		const created = await saleor(
+			`mutation($input: CollectionCreateInput!) {
+				collectionCreate(input: $input) { collection { id } errors { field message } }
+			}`,
+			{
+				input: {
+					name: "Plans",
+					slug: collectionSlug,
+					description: plaintextToEditorJs("Pick the plan that fits your store."),
+					products: productIds,
+				},
+			},
+		);
+		assertNoErrors(created, "collectionCreate", "collectionCreate");
+		collection = created.collectionCreate.collection;
+		console.log(`  created collection ${collection.id}`);
+	} else {
+		console.log(`  collection already exists: ${collection.id}`);
+	}
+
+	const published = await saleor(
+		`mutation($id: ID!, $input: CollectionChannelListingUpdateInput!) {
+			collectionChannelListingUpdate(id: $id, input: $input) { collection { id } errors { field message } }
+		}`,
+		{ id: collection.id, input: { addChannels: [{ channelId: channel.id, isPublished: true }] } },
+	);
+	assertNoErrors(published, "collectionChannelListingUpdate", "collectionChannelListingUpdate");
+	console.log(`  published collection to channel ${CHANNEL_SLUG}`);
+
+	// --- 6. Confirm vendor.saleorChannel in Strapi (should already be set) ---
+	console.log("Confirming vendor.saleorChannel in Strapi...");
+	const vendorResponse = await strapi(`/api/vendors?filters[vendorCode][$eq]=rovershop`);
+	const matches = (vendorResponse.data ?? []).filter((v) => v.vendorCode === "rovershop");
+	// Never trust "first item in the response" alone — assert the filter
+	// actually did its job client-side too, and refuse to guess if it
+	// didn't. A prior run of this exact step silently wrote to the wrong
+	// vendor (the /api/vendors list endpoint was, at the time, ignoring the
+	// filters query param entirely and returning everything) — this is the
+	// direct fix for that incident, not a hypothetical concern.
+	if (matches.length > 1) {
+		throw new Error(`Expected exactly one vendor with vendorCode "rovershop", found ${matches.length}`);
+	}
+	const vendor = matches[0];
+	if (vendor && vendor.saleorChannel !== CHANNEL_SLUG) {
+		await strapi(`/api/vendors/${vendor.documentId}`, {
+			method: "PUT",
+			body: JSON.stringify({ data: { saleorChannel: CHANNEL_SLUG } }),
+		});
+		console.log(`  updated vendor.saleorChannel: "${vendor.saleorChannel}" -> "${CHANNEL_SLUG}"`);
+	} else if (vendor) {
+		console.log(`  vendor.saleorChannel already "${CHANNEL_SLUG}"`);
+	} else {
+		console.warn('  no vendor found with vendorCode "rovershop" — skipping Strapi update');
+	}
+
+	console.log("Done.");
+	console.log(`  rovershop channel: ${channel.id}, ${productIds.length} products`);
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/scripts/register-rovershop-order-webhook.mjs
+++ b/scripts/register-rovershop-order-webhook.mjs
@@ -53,6 +53,16 @@ const SUBSCRIPTION_QUERY = `subscription {
 				userEmail
 				total { gross { amount currency } }
 				metadata { key value }
+				billingAddress {
+					firstName
+					lastName
+					streetAddress1
+					streetAddress2
+					city
+					countryArea
+					postalCode
+					country { code }
+				}
 				lines {
 					productName
 					quantity
@@ -153,6 +163,28 @@ async function main() {
 		if (webhook.targetUrl !== targetUrl) {
 			console.warn(`  WARNING: existing targetUrl "${webhook.targetUrl}" differs from expected "${targetUrl}" — not auto-updating; review manually.`);
 		}
+		// Update the subscription query + secret in place so schema changes to
+		// SUBSCRIPTION_QUERY (e.g. adding billingAddress) actually reach Saleor —
+		// the query is stored ON the webhook, not read from this script at
+		// delivery time, so without this an existing webhook keeps sending the
+		// old payload shape forever. Idempotent: re-running with an unchanged
+		// query is a no-op update.
+		const updated = await saleor(
+			`mutation($id: ID!, $input: WebhookUpdateInput!) {
+				webhookUpdate(id: $id, input: $input) { webhook { id } errors { field message code } }
+			}`,
+			{
+				id: webhook.id,
+				input: {
+					query: SUBSCRIPTION_QUERY,
+					secretKey: SALEOR_ORDER_WEBHOOK_SECRET,
+					asyncEvents: ["ORDER_CREATED"],
+					isActive: true,
+				},
+			},
+		);
+		assertNoErrors(updated, "webhookUpdate", "webhookUpdate");
+		console.log(`  updated webhook ${webhook.id} subscription query + secret`);
 	}
 
 	console.log("Done.");

--- a/scripts/register-rovershop-order-webhook.mjs
+++ b/scripts/register-rovershop-order-webhook.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Registers the ORDER_CREATED webhook that drives automatic vendor
+ * provisioning: when a customer completes checkout for a RoverStore
+ * subscription product (rovershop channel), Strapi's
+ * POST /api/webhooks/saleor-order-created receiver picks it up and enqueues
+ * a `provision-vendor-from-order` task.
+ *
+ * Attached to the existing "rovershop-vendor-dashboard" LOCAL app (id
+ * verified live against the real Saleor instance) — confirmed empirically
+ * that Saleor's staff tokenCreate auth (the same auth every other
+ * provisioning script in this repo already uses) can create/delete
+ * webhooks on an existing app; no App-scoped auth token is needed.
+ *
+ * Idempotent: check-before-create by `name` (webhooks have no slug).
+ * Rerunning this script is safe.
+ *
+ * Usage:
+ *   SALEOR_API_URL=https://api.rovershop.io/graphql/ \
+ *   SALEOR_ADMIN_EMAIL=admin@rovershop.io \
+ *   SALEOR_ADMIN_PASSWORD=... \
+ *   STRAPI_API_URL=https://api.roverai.io \
+ *   SALEOR_ORDER_WEBHOOK_SECRET=... \
+ *   node scripts/register-rovershop-order-webhook.mjs
+ */
+
+const SALEOR_API_URL = process.env.SALEOR_API_URL ?? "https://api.rovershop.io/graphql/";
+const SALEOR_ADMIN_EMAIL = requireEnv("SALEOR_ADMIN_EMAIL");
+const SALEOR_ADMIN_PASSWORD = requireEnv("SALEOR_ADMIN_PASSWORD");
+const STRAPI_API_URL = process.env.STRAPI_API_URL ?? "https://api.roverai.io";
+const SALEOR_ORDER_WEBHOOK_SECRET = requireEnv("SALEOR_ORDER_WEBHOOK_SECRET");
+
+const WEBHOOK_NAME = "rovershop-order-created";
+// The "rovershop-vendor-dashboard" LOCAL app — reused rather than creating a
+// dedicated app, since it's already the first-party app this ecosystem uses
+// for server-to-server Saleor access (as opposed to Rover Pay, a THIRDPARTY
+// payment-gateway app). Verified live: this id is stable across environments
+// only if re-provisioned identically; re-resolved by name below rather than
+// hardcoded, so this script stays correct if the id ever differs.
+const APP_NAME = "rovershop-vendor-dashboard";
+
+// Saleor subscription-query DSL for the ORDER_CREATED event payload. Verified
+// live via webhookDryRun against a real order — the payload the receiver
+// gets is exactly `{ order: { ... } }`, no extra `event` wrapper despite the
+// `subscription { event { ... on OrderCreated { ... } } }` query shape.
+const SUBSCRIPTION_QUERY = `subscription {
+	event {
+		... on OrderCreated {
+			order {
+				id
+				number
+				channel { slug }
+				userEmail
+				total { gross { amount currency } }
+				metadata { key value }
+				lines {
+					productName
+					quantity
+					variant {
+						id
+						sku
+						product { metadata { key value } }
+					}
+				}
+			}
+		}
+	}
+}`;
+
+function requireEnv(name) {
+	const value = process.env[name];
+	if (!value) {
+		console.error(`Missing required env var ${name}`);
+		process.exit(1);
+	}
+	return value;
+}
+
+let saleorToken;
+
+async function saleor(query, variables = {}) {
+	const response = await fetch(SALEOR_API_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...(saleorToken ? { Authorization: `Bearer ${saleorToken}` } : {}),
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+	const json = await response.json();
+	if (json.errors) {
+		throw new Error(`Saleor GraphQL error: ${JSON.stringify(json.errors)}`);
+	}
+	return json.data;
+}
+
+function assertNoErrors(result, mutationKey, label) {
+	const errors = result?.[mutationKey]?.errors;
+	if (errors && errors.length > 0) {
+		throw new Error(`${label} failed: ${JSON.stringify(errors)}`);
+	}
+}
+
+async function main() {
+	console.log("Authenticating to Saleor...");
+	const tokenResult = await saleor(
+		`mutation TokenCreate($email: String!, $password: String!) {
+			tokenCreate(email: $email, password: $password) { token errors { field message } }
+		}`,
+		{ email: SALEOR_ADMIN_EMAIL, password: SALEOR_ADMIN_PASSWORD },
+	);
+	assertNoErrors(tokenResult, "tokenCreate", "Saleor auth");
+	saleorToken = tokenResult.tokenCreate.token;
+
+	console.log(`Resolving app "${APP_NAME}"...`);
+	const apps = (await saleor(`{ apps(first: 20) { edges { node { id name } } } }`)).apps.edges.map((e) => e.node);
+	const app = apps.find((a) => a.name === APP_NAME);
+	if (!app) {
+		throw new Error(`App "${APP_NAME}" not found — expected it to already exist`);
+	}
+	console.log(`  resolved app: ${app.id}`);
+
+	console.log(`Ensuring webhook "${WEBHOOK_NAME}" exists...`);
+	const existingWebhooks = (await saleor(`query($id: ID!) { app(id: $id) { webhooks { id name targetUrl isActive } } }`, {
+		id: app.id,
+	})).app.webhooks;
+	let webhook = existingWebhooks.find((w) => w.name === WEBHOOK_NAME);
+
+	const targetUrl = `${STRAPI_API_URL}/api/webhooks/saleor-order-created`;
+
+	if (!webhook) {
+		const created = await saleor(
+			`mutation($input: WebhookCreateInput!) {
+				webhookCreate(input: $input) { webhook { id name targetUrl isActive } errors { field message code } }
+			}`,
+			{
+				input: {
+					name: WEBHOOK_NAME,
+					targetUrl,
+					app: app.id,
+					asyncEvents: ["ORDER_CREATED"],
+					isActive: true,
+					secretKey: SALEOR_ORDER_WEBHOOK_SECRET,
+					query: SUBSCRIPTION_QUERY,
+				},
+			},
+		);
+		assertNoErrors(created, "webhookCreate", "webhookCreate");
+		webhook = created.webhookCreate.webhook;
+		console.log(`  created webhook ${webhook.id} -> ${webhook.targetUrl}`);
+	} else {
+		console.log(`  webhook already exists: ${webhook.id} -> ${webhook.targetUrl}`);
+		if (webhook.targetUrl !== targetUrl) {
+			console.warn(`  WARNING: existing targetUrl "${webhook.targetUrl}" differs from expected "${targetUrl}" — not auto-updating; review manually.`);
+		}
+	}
+
+	console.log("Done.");
+	console.log(`  webhook: ${webhook.id}, target: ${targetUrl}, event: ORDER_CREATED`);
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "supabase": {
+      "source": "supabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/supabase/SKILL.md",
+      "computedHash": "61638e85394d2e39d1109cbf607593afb9733e0de19cdf0b52ec9bc32d95ea74"
+    },
+    "supabase-postgres-best-practices": {
+      "source": "supabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/supabase-postgres-best-practices/SKILL.md",
+      "computedHash": "3639bed1f40b3fbadae79fee631c42c89b2d1f5c30b05d5aa3cca06422a6bbbc"
+    }
+  }
+}


### PR DESCRIPTION
Idempotent Saleor seeding for the 4 Bytes (⬡) top-up products on the existing **roverchat** channel (chat.rovershop.ai), part of #61 (close the billing loop). Each product carries `roverstoreProduct: chat-tokens` + `roverstoreBytes: <amount>` metadata; on ORDER_CREATED the Strapi webhook credits the buyer's wallet via the new `credit-chat-bytes-from-order` task.

| Product | Bytes | Price |
|---|---|---|
| rc-bytes-snack | 5,000 | $4.99 |
| rc-bytes-fuel ⭐ | 15,000 | $11.99 |
| rc-bytes-power | 40,000 | $27.99 |
| rc-bytes-mega | 100,000 | $59.99 |

Priced to beat Poe ($30/1M compute points) while cost-safe on gpt-5; Bytes never expire. Prices are the single source of truth in `roverchat-dashboard-web/src/lib/bytes-packages.ts`.

**Already run against production** — the products are live, published, priced, and purchasable on the roverchat channel (verified via a follow-up GraphQL query). Kept in-repo for reproducibility (mirrors `provision-rovershop-subscriptions.mjs`; idempotent, safe to re-run).

Refs #61